### PR TITLE
Code clean-up in submodules.

### DIFF
--- a/src/specialmatrices_bidiagonal.f90
+++ b/src/specialmatrices_bidiagonal.f90
@@ -9,60 +9,29 @@ contains
    !-----     Constructors     -----
    !--------------------------------
 
-   pure module function initialize_bidiag(n, which) result(A)
-      !! Utility function to construct a `Bidiagonal` matrix filled with zeros.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      character(len=1), optional, intent(in) :: which
-      !! Whether `A` has a sub- or super-diagonal.
-      type(Bidiagonal) :: A
-      !! Corresponding bidiagonal matrix.
+   module procedure initialize_bidiag
+      ! Utility procedure to construct a `Bidiagonal` matrix filled with zeros.
       A%n = n; A%which = optval(which, "L")
       allocate(A%dv(n), A%ev(n-1)); A%dv = 0.0_dp; A%ev = 0.0_dp
-      return
-   end function initialize_bidiag
+   end procedure initialize_bidiag
 
-   pure module function construct_bidiag(dv, ev, which) result(A)
-      !! Utility function to construct a `Bidiagonal` matrix from rank-1 arrays.
-      real(dp), intent(in) :: dv(:), ev(:)
-      !! Diagonal elements of the matrix.
-      character(len=1), optional, intent(in) :: which
-      !! Whether `A` has a sub- or super-diagonal.
-      type(Bidiagonal) :: A
-      !! Corresponding bidiagonal matrix.
+   module procedure construct_bidiag
+      !! Utility procedure to construct a `Bidiagonal` matrix from rank-1 arrays.
       A%n = size(dv); A%dv = dv ; A%ev = ev ; A%which = optval(which, "L")
-      return
-   end function construct_bidiag
+   end procedure construct_bidiag
 
-   pure module function construct_constant_bidiag(d, e, n, which) result(A)
-      !! Utility function to construct a `Bidiagonal` matrix with constant elements.
-      real(dp), intent(in) :: d, e
-      !! Constant diagonal elements.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      character(len=1), optional, intent(in) :: which
-      !! Whether `A` has a sub- or super-diagonal.
-      type(Bidiagonal) :: A
-      !! Corresponding bidiagonal matrix.
+   module procedure construct_constant_bidiag
+      !! Utility procedure to construct a `Bidiagonal` matrix with constant elements.
       integer :: i
       A%n = n; A%which = optval(which, "L")
       A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
-      return
-   end function construct_constant_bidiag
+   end procedure construct_constant_bidiag
 
    !------------------------------------------------------------
    !-----     Matrix-vector and Matrix-matrix products     -----
    !------------------------------------------------------------
 
-   pure module function bidiag_spmv(A, x) result(y)
-      !! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
-      !! is of type `Bidiagonal` and `x` and `y` are both rank-1 arrays.
-      type(Bidiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: x(:)
-      !! Input vector.
-      real(dp) :: y(size(x))
-      !! Output vector.
+   module procedure bidiag_spmv
       integer(ilp) :: i, n
       n = size(x)
       if (A%which == "L") then
@@ -76,125 +45,70 @@ contains
          enddo
          y(n) = A%dv(n) * x(n)
       endif
-      return
-   end function bidiag_spmv
+   end procedure bidiag_spmv
 
-   pure module function bidiag_multi_spmv(A, X) result(Y)
-      !! Utility function to compute the matrix-matrix product \( Y = AX \) where \( A \)
-      !! is of type `Bidiagonal` and `X` and `Y` are both rank-2 arrays.
-      type(Bidiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: X(:, :)
-      !! Input matrix (rank-2 array).
-      real(dp) :: Y(size(X, 1), size(X, 2))
-      !! Output matrix (rank-2 array).
+   module procedure bidiag_multi_spmv
       integer(ilp) :: i, n
       n = size(x)
       do concurrent (i=1:size(X, 2))
          Y(:, i) = bidiag_spmv(A, X(:, i))
       enddo
-      return
-   end function bidiag_multi_spmv
+   end procedure bidiag_multi_spmv
 
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
 
-   pure module function bidiag_solve(A, b) result(x)
-      !! Utility function to solve the linear system \( Ax = b \) where \( A \) is a
-      !! `Bidiagonal` matrix and `b` a rank-1 array. The solution `x` is also a rank-1
-      !! array with the same type and dimesnion as `b`.
-      type(Bidiagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: b(:)
-      !! Right-hand side vector.
-      real(dp) :: x(size(b))
-      !! Solution vector.
+   module procedure bidiag_solve
       real(dp) :: dl(A%n-1), dv(A%n), du(A%n-1), b_(A%n, 1)
       integer :: n, nrhs, info
-
       ! Initialize array.
       n = A%n; b_(:, 1) = b; nrhs = 1; dv = A%dv
-
       ! Dispatch based on upper- or lower-bidiagonal.
       if (A%which == "L") then
          dl = A%ev; du = 0.0_dp
       elseif (A%which == "U") then
          dl = 0.0_dp; du = A%ev
       endif
-
       ! Solve the system using a tridiagonal solver.
       call gtsv(n, nrhs, dl, dv, du, b_, n, info)
-
       ! Return the solution.
       x = b_(:, 1)
-      
-      return
-   end function bidiag_solve
+   end procedure bidiag_solve
 
-   pure module function bidiag_multi_solve(A, B) result(X)
-      !! Utility function to solve the linear system with multiple right-hand side where 
-      !!  \( A \) is a `Bidiagonal` matrix and `B` a rank-2 array. The solution `x` is also
-      !! a rank-2 array with the same type and dimesnion as `B`.
-      type(Bidiagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: B(:, :)
-      !! Right-hand side vector.
-      real(dp) :: X(size(B, 1), size(B, 2))
-      !! Solution vector.
+   module procedure bidiag_multi_solve
       real(dp) :: dl(A%n-1), dv(A%n), du(A%n-1), b_(A%n, 1)
       integer(ilp) :: n, nrhs, info
-
       ! Initialize array.
       n = A%n; X = B; nrhs = size(X, 2); dv = A%dv
-
       ! Dispatch based on upper- or lower-bidiagonal.
       if (A%which == "L") then
          dl = A%ev; du = 0.0_dp
       elseif (A%which == "U") then
          dl = 0.0_dp; du = A%ev
       endif
-
       ! Solve the system using a tridiagonal solver.
       call gtsv(n, nrhs, dl, dv, du, X, n, info)
-
-      return
-   end function bidiag_multi_solve
+   end procedure bidiag_multi_solve
 
    !------------------------------------
-   !-----     Utility function     -----
+   !-----     Utility procedure     -----
    !------------------------------------
 
-   pure module function bidiag_shape(A) result(shape)
-      !! Utility function to return the shape of a `Bidiagonal` matrix.
-      type(Bidiagonal), intent(in) ::A
-      !! Input matrix.
-      integer(ilp) :: shape(2)
-      !! Shape of the matrix.
+   module procedure bidiag_shape
       shape = A%n
-   end function bidiag_shape
+   end procedure bidiag_shape
 
-   pure module function bidiag_transpose(A) result(B)
-      !! Utility function to compute the transpose of a `Bidiagonal` matrix.
-      type(Bidiagonal), intent(in) :: A
-      !! Input bidiagonal matrix.
-      type(Bidiagonal) :: B
-      !! Transpose of the original matrix.
+   module procedure bidiag_transpose
       B = A
       if (A%which == "L") then
          B%which = "U"
       else
          B%which = "L"
       endif
-      return
-   end function bidiag_transpose
+   end procedure bidiag_transpose
 
-   pure module function bidiag_to_dense(A) result(B)
-      !! Utility function to convert a `Bidiagonal` matrix to a regular rank-2 array.
-      type(Bidiagonal), intent(in) :: A
-      !! Input bidiagonal matrix.
-      real(dp) :: B(A%n, A%n)
-      !! Output dense rank-2 array.
+   module procedure bidiag_to_dense
       integer(ilp) :: i, n
       n = A%n; B = 0.0_dp
       if (A%which == "L") then
@@ -210,7 +124,6 @@ contains
          enddo
          B(n, n) = A%dv(n)
       endif
-      return
-   end function bidiag_to_dense
+   end procedure bidiag_to_dense
 
 end submodule BidiagonalMatrices

--- a/src/specialmatrices_bidiagonal.f90
+++ b/src/specialmatrices_bidiagonal.f90
@@ -33,7 +33,7 @@ contains
 
    module procedure bidiag_spmv
       integer(ilp) :: i, n
-      n = size(x)
+      n = size(x); allocate(y, mold=x)
       if (A%which == "L") then
          y(1) = A%dv(1) * x(1)
          do concurrent (i=2:n)
@@ -49,7 +49,7 @@ contains
 
    module procedure bidiag_multi_spmv
       integer(ilp) :: i, n
-      n = size(x)
+      n = size(x); allocate(Y, mold=X)
       do concurrent (i=1:size(X, 2))
          Y(:, i) = bidiag_spmv(A, X(:, i))
       enddo

--- a/src/specialmatrices_bidiagonal.f90
+++ b/src/specialmatrices_bidiagonal.f90
@@ -22,7 +22,7 @@ contains
 
    module procedure construct_constant_bidiag
       !! Utility procedure to construct a `Bidiagonal` matrix with constant elements.
-      integer :: i
+      integer(ilp) :: i
       A%n = n; A%which = optval(which, "L")
       A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
    end procedure construct_constant_bidiag
@@ -61,7 +61,7 @@ contains
 
    module procedure bidiag_solve
       real(dp) :: dl(A%n-1), dv(A%n), du(A%n-1), b_(A%n, 1)
-      integer :: n, nrhs, info
+      integer(ilp) :: n, nrhs, info
       ! Initialize array.
       n = A%n; b_(:, 1) = b; nrhs = 1; dv = A%dv
       ! Dispatch based on upper- or lower-bidiagonal.

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -10,169 +10,101 @@ contains
    !-----     Constructors     -----
    !--------------------------------
 
-   pure module function initialize_diag(n) result(A)
-      !! Utility function to construct a `Diagonal` matrix filled with zeros.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(Diagonal) :: A
-      !! Corresponding diagonal matrix.
+   module procedure initialize_diag
+      ! Utility function to construct a `Diagonal` matrix filled with zeros.
       A%n = n; allocate(A%dv(n)); A%dv = 0.0_dp
-      return
-   end function initialize_diag
+   end procedure initialize_diag
 
-   pure module function construct_diag(dv) result(A)
-      !! Utility function to construct a `Diagonal` matrix from a rank-1 array.
-      real(dp), intent(in) :: dv(:)
-      !! Diagonal element of the matrix.
-      type(Diagonal) :: A
-      !! Corresponding diagonal matrix.
+   module procedure construct_diag
+      ! Utility function to construct a `Diagonal` matrix from a rank-1 array.
       A%n = size(dv); A%dv = dv
-      return
-   end function construct_diag
+   end procedure construct_diag
 
-   pure module function construct_constant_diag(d, n) result(A)
-      !! Utility function to construct a `Diagonal` matrix with constant diagonal element.
-      real(dp), intent(in) :: d
-      !! Constant diagonal element of the matrix.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(Diagonal) :: A
-      !! Corresponding diagonal matrix.
+   module procedure construct_constant_diag
+      ! Utility function to construct a `Diagonal` matrix with constant diagonal element.
       integer :: i
       A%n = n; A%dv = [(d, i=1, n)]
-      return
-   end function construct_constant_diag
+   end procedure construct_constant_diag
 
-   module function construct_dense_to_diag(A) result(B)
-      !! Utility function to construct a `Diagonal` matrix from a rank-2 array.
-      real(dp), intent(in) :: A(:, :)
-      !! Dense [n x n] matrix from which to construct the `Diagonal` one.
-      type(Diagonal) :: B
-      !! Corresponding diagonal matrix.
+   module procedure construct_dense_to_diag
+      ! Utility function to construct a `Diagonal` matrix from a rank-2 array.
       B = Diagonal(diag(A))
-      return
-   end function construct_dense_to_diag
+   end procedure construct_dense_to_diag
 
    !------------------------------------------------------------
    !-----     Matrix-vector and matrix-matrix products     -----
    !------------------------------------------------------------
 
-   pure module function diag_spmv(A, x) result(y)
-      !! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
-      !! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
-      type(Diagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: x(:)
-      !! Input vector.
-      real(dp) :: y(size(x))
-      !! Output vector.
+   module procedure diag_spmv
+      ! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
+      ! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
       integer :: i
       do concurrent(i=1:size(x))
          y(i) = A%dv(i) * x(i)
       enddo
-      return
-   end function diag_spmv
+   end procedure diag_spmv
 
-   pure module function diag_multi_spmv(A, X) result(Y)
-      !! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
-      !! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
-      type(Diagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: X(:, :)
-      !! Input matrix (rank-2 array).
-      real(dp) :: Y(size(X, 1), size(X, 2))
-      !! Output matrix (rank-2 array).
+   module procedure diag_multi_spmv
+      ! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
+      ! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
       integer :: i, j
       do concurrent(i=1:size(X, 1), j=1:size(X, 2))
          Y(i, j) = A%dv(i) * X(i, j)
       enddo
-      return
-   end function diag_multi_spmv
+   end procedure diag_multi_spmv
 
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
 
-   pure module function diag_solve(A, b) result(x)
-      !! Utility function to solve the linear system \( A x = b \) where \( A \) is of
-      !! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
-      !! with the same type and dimension of `b`.
-      type(Diagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: b(:)
-      !! Right-hande side vector.
-      real(dp), allocatable :: x(:)
-      !! Solution vector.
+   module procedure diag_solve
+      ! Utility function to solve the linear system \( A x = b \) where \( A \) is of
+      ! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
+      ! with the same type and dimension of `b`.
       integer :: i, n
       if (.not. allocated(x)) allocate(x, mold=b)
       do concurrent(i=1:A%n)
          x(i) = b(i) / A%dv(i)
       enddo
-      return
-   end function diag_solve
+   end procedure diag_solve
 
-   pure module function diag_multi_solve(A, B) result(X)
-      !! Utility function to solve a linear system with multiple right-hande sides where \( A \)
-      !! is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
-      !! with the same type and dimensions as `B`.
-      type(Diagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: B(:, :)
-      !! Right-hand side vectors.
-      real(dp), allocatable :: X(:, :)
-      !! Solution vectors.
+   module procedure diag_multi_solve
+      ! Utility function to solve a linear system with multiple right-hande sides where \( A \)
+      ! is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
+      ! with the same type and dimensions as `B`.
       integer(ilp) :: i, j
       real(dp) :: inv_dv(A%n)
       if (.not. allocated(X)) allocate(X, mold=B); inv_dv = 1.0_dp / A%dv
       do concurrent(i=1:A%n, j=1:size(B, 2))
          X(i, j) = B(i, j) * inv_dv(i)
       enddo
-      return
-   end function diag_multi_solve
+   end procedure diag_multi_solve
 
-   pure module subroutine diag_eig(A, lambda, vectors)
-      type(Diagonal), intent(in) :: A
-      real(dp), intent(out) :: lambda(A%n)
-      real(dp), intent(out) :: vectors(A%n, A%n)
-
+   module procedure diag_eig
       lambda = A%dv ; vectors = eye(A%n)
-      return
-   end subroutine diag_eig
+   end procedure diag_eig
 
    !------------------------------------
    !-----     Utility function     -----
    !------------------------------------
 
-   pure module function diag_to_dense(A) result(B)
-      !! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
-      type(Diagonal), intent(in) :: A
-      !! Input diagonal matrix.
-      real(dp) :: B(A%n, A%n)
-      !! Output dense rank-2 array.
+   module procedure diag_to_dense
+      ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
       integer :: i
       B = 0.0_dp
       do concurrent(i=1:A%n)
          B(i, i) = A%dv(i)
       enddo
-   end function diag_to_dense
+   end procedure diag_to_dense
 
-   pure module function diag_transpose(A) result(B)
-      !! Utility function to compute the transpose of a `Diagonal` matrix.
-      type(Diagonal), intent(in) :: A
-      !! Input matrix.
-      type(Diagonal) :: B
-      !! Transposed matrix.
+   module procedure diag_transpose
+      ! Utility function to compute the transpose of a `Diagonal` matrix.
       B = A
-   end function diag_transpose
+   end procedure diag_transpose
 
-   pure module function diag_shape(A) result(shape)
-      !! Utility function to get the shape of a `Diagonal` matrix.
-      type(Diagonal), intent(in) :: A
-      !! Input matrix.
-      integer(ilp) :: shape(2)
-      !! Shape of the matrix.
+   module procedure diag_shape
+      ! Utility function to get the shape of a `Diagonal` matrix.
       shape = A%n
-      return
-   end function diag_shape
+   end procedure diag_shape
    
 end submodule DiagonalMatrices

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -22,7 +22,7 @@ contains
 
    module procedure construct_constant_diag
       ! Utility function to construct a `Diagonal` matrix with constant diagonal element.
-      integer :: i
+      integer(ilp) :: i
       A%n = n; A%dv = [(d, i=1, n)]
    end procedure construct_constant_diag
 
@@ -38,7 +38,7 @@ contains
    module procedure diag_spmv
       ! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
       ! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
-      integer :: i
+      integer(ilp) :: i
       allocate(y, mold=x)
       do concurrent(i=1:size(x))
          y(i) = A%dv(i) * x(i)
@@ -48,7 +48,7 @@ contains
    module procedure diag_multi_spmv
       ! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
       ! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
-      integer :: i, j
+      integer(ilp) :: i, j
       allocate(Y, mold=X)
       do concurrent(i=1:size(X, 1), j=1:size(X, 2))
          Y(i, j) = A%dv(i) * X(i, j)
@@ -63,7 +63,7 @@ contains
       ! Utility function to solve the linear system \( A x = b \) where \( A \) is of
       ! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
       ! with the same type and dimension of `b`.
-      integer :: i, n
+      integer(ilp) :: i, n
       allocate(x, mold=b)
       do concurrent(i=1:A%n)
          x(i) = b(i) / A%dv(i)
@@ -92,7 +92,7 @@ contains
 
    module procedure diag_to_dense
       ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
-      integer :: i
+      integer(ilp) :: i
       B = 0.0_dp
       do concurrent(i=1:A%n)
          B(i, i) = A%dv(i)

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -64,7 +64,7 @@ contains
       ! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
       ! with the same type and dimension of `b`.
       integer :: i, n
-      if (.not. allocated(x)) allocate(x, mold=b)
+      allocate(x, mold=b)
       do concurrent(i=1:A%n)
          x(i) = b(i) / A%dv(i)
       enddo
@@ -76,7 +76,7 @@ contains
       ! with the same type and dimensions as `B`.
       integer(ilp) :: i, j
       real(dp) :: inv_dv(A%n)
-      if (.not. allocated(X)) allocate(X, mold=B); inv_dv = 1.0_dp / A%dv
+      allocate(X, mold=B); inv_dv = 1.0_dp / A%dv
       do concurrent(i=1:A%n, j=1:size(B, 2))
          X(i, j) = B(i, j) * inv_dv(i)
       enddo

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -39,6 +39,7 @@ contains
       ! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
       ! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
       integer :: i
+      allocate(y, mold=x)
       do concurrent(i=1:size(x))
          y(i) = A%dv(i) * x(i)
       enddo
@@ -48,6 +49,7 @@ contains
       ! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
       ! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
       integer :: i, j
+      allocate(Y, mold=X)
       do concurrent(i=1:size(X, 1), j=1:size(X, 2))
          Y(i, j) = A%dv(i) * X(i, j)
       enddo

--- a/src/specialmatrices_symtridiagonal.f90
+++ b/src/specialmatrices_symtridiagonal.f90
@@ -18,7 +18,7 @@ contains
    end procedure construct_symtridiag
 
    module procedure construct_constant_symtridiag
-      integer i
+      integer(ilp) :: i
       A%n = n; A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
    end procedure construct_constant_symtridiag
 
@@ -27,7 +27,7 @@ contains
    !------------------------------------------------------------
 
    module procedure symtridiag_spmv
-     integer :: i, n
+      integer(ilp) :: i, n
       n = size(x); allocate(y, mold=x)
       y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
       do concurrent (i=2:n-1)
@@ -37,7 +37,7 @@ contains
    end procedure symtridiag_spmv
 
    module procedure symtridiag_multi_spmv
-     integer(ilp) :: i
+      integer(ilp) :: i
       allocate(Y, mold=X)
       do concurrent(i=1:size(X,2))
          Y(:, i) = symtridiag_spmv(A, X(:, i))
@@ -49,7 +49,7 @@ contains
    !----------------------------------
 
    module procedure symtridiag_solve
-      integer :: i, n, nrhs, info
+      integer(ilp) :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
       ! Initialize arrays.
       n = A%n; dl = A%ev; d = A%dv; du = A%ev; b_(:, 1) = b ; nrhs = 1
@@ -60,7 +60,7 @@ contains
    end procedure symtridiag_solve
 
    module procedure symtridiag_multi_solve
-      integer :: i, n, nrhs, info
+      integer(ilp) :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
       ! Initialize arrays.
       n = A%n; dl = A%ev; d = A%dv; du = A%ev; nrhs = size(B, 2); X = B
@@ -73,7 +73,7 @@ contains
    !-------------------------------------
 
    module procedure symtridiag_to_dense
-      integer :: i, n
+      integer(ilp) :: i, n
       n = A%n; B = 0.0_dp
       B(1, 1) = A%dv(1); B(1, 2) = A%ev(1)
       do concurrent(i=2:n - 1)

--- a/src/specialmatrices_symtridiagonal.f90
+++ b/src/specialmatrices_symtridiagonal.f90
@@ -28,7 +28,8 @@ contains
 
    module procedure symtridiag_spmv
      integer :: i, n
-      n = size(x); y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
+      n = size(x); allocate(y, mold=x)
+      y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
       do concurrent (i=2:n-1)
          y(i) = A%ev(i-1)*x(i-1) + A%dv(i)*x(i) + A%ev(i)*x(i+1)
       enddo
@@ -37,6 +38,7 @@ contains
 
    module procedure symtridiag_multi_spmv
      integer(ilp) :: i
+      allocate(Y, mold=X)
       do concurrent(i=1:size(X,2))
          Y(:, i) = symtridiag_spmv(A, X(:, i))
       enddo

--- a/src/specialmatrices_symtridiagonal.f90
+++ b/src/specialmatrices_symtridiagonal.f90
@@ -8,137 +8,69 @@ contains
    !-----     Constructors     -----
    !--------------------------------
 
-   pure module function initialize_symtridiag(n) result(A)
-      !! Utility function to create a `SymTridiagonal` matrix filled with zeros.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(SymTridiagonal) :: A
-      !! Corresponding symmetric tridiagonal matrix.
+   module procedure initialize_symtridiag
       A%n = n; allocate(A%dv(n), A%ev(n-1))
       A%dv = 0.0_dp; A%ev = 0.0_dp
-      return
-   end function initialize_symtridiag
+   end procedure initialize_symtridiag
 
-   pure module function construct_symtridiag(dv, ev) result(A)
-      !! Utility function to create a `SymTridiagonal` matrix from rank-1 arrays.
-      real(dp), intent(in) :: dv(:), ev(:)
-      !! Diagonal elements of the matrix.
-      type(SymTridiagonal) :: A
-      !! Corresponding symmetric tridiagonal matrix.
+   module procedure construct_symtridiag
       A%n = size(dv); A%dv = dv; A%ev = ev
-      return
-   end function construct_symtridiag
+   end procedure construct_symtridiag
 
-   pure module function construct_constant_symtridiag(d, e, n) result(A)
-      !! Utility function to create a `SymTridiagonal` matrix with constant diagonal elements.
-      real(dp), intent(in) :: d, e
-      !! Constant diagonal elements of the matrix.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(SymTridiagonal) :: A
-      !! Corresponding symmetric tridiagonal matrix.
+   module procedure construct_constant_symtridiag
       integer i
       A%n = n; A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
-      return
-   end function construct_constant_symtridiag
+   end procedure construct_constant_symtridiag
 
    !------------------------------------------------------------
    !-----     Matrix-vector and Matrix-matrix products     -----
    !------------------------------------------------------------
 
-   pure module function symtridiag_spmv(A, x) result(y)
-      !! Utility function to compute the matrix-vector product where \( A \) is of
-      !! `SymTridiagonal` type and `x` and `y` are both rank-1 arrays.
-      type(SymTridiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: x(:)
-      !! Input vector.
-      real(dp) :: y(size(x))
-      !! Output vector.
-      integer :: i, n
+   module procedure symtridiag_spmv
+     integer :: i, n
       n = size(x); y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
       do concurrent (i=2:n-1)
          y(i) = A%ev(i-1)*x(i-1) + A%dv(i)*x(i) + A%ev(i)*x(i+1)
       enddo
       y(n) = A%dv(n)*x(n) + A%ev(n-1)*x(n-1)
-      return
-   end function symtridiag_spmv
+   end procedure symtridiag_spmv
 
-   pure module function symtridiag_multi_spmv(A, X) result(Y)
-      !! Utility function to compute matrix-matrix product where \( A \) is of
-      !! `SymTridiagonal` type and `X` and `Y` are both rank-2 arrays.
-      type(SymTridiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: X(:, :)
-      !! Input matrix (rank-2 array).
-      real(dp) :: Y(size(X, 1), size(X, 2))
-      !! Output matrix (rank-2 array).
-      integer(ilp) :: i
+   module procedure symtridiag_multi_spmv
+     integer(ilp) :: i
       do concurrent(i=1:size(X,2))
          Y(:, i) = symtridiag_spmv(A, X(:, i))
       enddo
-   end function symtridiag_multi_spmv
+   end procedure symtridiag_multi_spmv
 
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
 
-   pure module function symtridiag_solve(A, b) result(x)
-      !! Utility function to solve a linear system \( Ax = b \) where \( A \) is of
-      !! `SymTridiagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
-      !! with the same type and dimension as `b`.
-      type(SymTridiagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: b(:)
-      !! Right-hand side vector.
-      real(dp) :: x(size(b))
-      !! Solution vector.
+   module procedure symtridiag_solve
       integer :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
-
       ! Initialize arrays.
       n = A%n; dl = A%ev; d = A%dv; du = A%ev; b_(:, 1) = b ; nrhs = 1
-
       ! Solve the system.
       call gtsv(n, nrhs, dl, d, du, b_, n, info)
-
       ! Return the solution.
       x = b_(:, 1)
+   end procedure symtridiag_solve
 
-      return
-   end function symtridiag_solve
-
-   pure module function symtridiag_multi_solve(A, B) result(X)
-      !! Utility function to solve a linear system with multiple right-hand sides where \( A \)
-      !! is of `SymTridiagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2
-      !! array with the same type and dimension as `B`.
-      type(SymTridiagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: B(:, :)
-      !! Right-hand side vectors.
-      real(dp) :: X(size(B, 1), size(B, 2))
-      !! Solution vectors.
+   module procedure symtridiag_multi_solve
       integer :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
-
       ! Initialize arrays.
       n = A%n; dl = A%ev; d = A%dv; du = A%ev; nrhs = size(B, 2); X = B
-
       ! Solve the systems.
       call gtsv(n, nrhs, dl, d, du, X, n, info)
-
-   end function symtridiag_multi_solve
+   end procedure symtridiag_multi_solve
 
    !-------------------------------------
-   !-----     Utility functions     -----
+   !-----     Utility procedures     -----
    !-------------------------------------
 
-   pure module function symtridiag_to_dense(A) result(B)
-      !! Utility function to convert a `SymTridiagonal` matrix to a regular rank-2 array.
-      type(SymTridiagonal), intent(in) :: A
-      !! Input symmetric tridiagonal matrix.
-      real(dp) :: B(A%n, A%n)
-      !! Output dense rank-2 array.
+   module procedure symtridiag_to_dense
       integer :: i, n
       n = A%n; B = 0.0_dp
       B(1, 1) = A%dv(1); B(1, 2) = A%ev(1)
@@ -148,27 +80,14 @@ contains
          B(i, i + 1) = A%ev(i)
       end do
       B(n, n - 1) = A%ev(n - 1); B(n, n) = A%dv(n)
-      return
-   end function symtridiag_to_dense
+   end procedure symtridiag_to_dense
 
-   pure module function symtridiag_transpose(A) result(B)
-      !! Utility function to compute the transpose of a `SymTridiagonal` matrix.
-      !! The output matrix is also of `SymTridiagonal` type.
-      type(SymTridiagonal), intent(in) :: A
-      !! Input symmetric tridiagonal matrix.
-      type(SymTridiagonal) :: B
-      !! Transpose of the original matrix.
+   module procedure symtridiag_transpose
       B = A
-      return
-   end function symtridiag_transpose
+   end procedure symtridiag_transpose
 
-   pure module function symtridiag_shape(A) result(shape)
-      type(SymTridiagonal), intent(in) :: A
-      !! Input matrix.
-      integer(ilp) :: shape(2)
-      !! Shape of the matrix.
+   module procedure symtridiag_shape
       shape(2) = A%n
-      return
-   end function symtridiag_shape
+   end procedure symtridiag_shape
 
 end submodule SymmetricTridiagonal

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -596,7 +596,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
          !! Right-hand side vector.
-         real(dp) :: x(size(b))
+         real(dp), allocatable :: x(:)
          !! Solution vector.
       end function bidiag_solve
 
@@ -608,7 +608,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
          !! Right-hand side vectors.
-         real(dp) :: X(size(B, 1), size(B, 2))
+         real(dp), allocatable :: X(:, :)
          !! Solution vectors.
       end function bidiag_multi_solve
 
@@ -622,7 +622,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
          !! Right-hand side vector.
-         real(dp) :: x(size(b))
+         real(dp), allocatable :: x(:)
          !! Solution vector.
       end function tridiag_solve
 
@@ -634,7 +634,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
          !! Right-hand side vectors.
-         real(dp) :: X(size(B, 1), size(B, 2))
+         real(dp), allocatable :: X(:, :)
          !! Solution vectors.
       end function tridiag_multi_solve
 
@@ -648,7 +648,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
          !! Right-hande side vector.
-         real(dp) :: x(size(b))
+         real(dp), allocatable :: x(:)
          !! Solution vector.
       end function symtridiag_solve
 
@@ -660,7 +660,7 @@ module SpecialMatrices_Tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
          !! Right-hand side vectors.
-         real(dp) :: X(size(B, 1), size(B, 2))
+         real(dp), allocatable :: X(:, :)
          !! Solution vectors.
       end function symtridiag_multi_solve
    end interface

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -21,6 +21,7 @@ module SpecialMatrices_Tridiagonal
    type, public :: Diagonal
       !! Base type used to define a `Diagonal` matrix of size [n x n] with diagonal given by the
       !! rank-1 array `dv`.
+      private
       integer(ilp) :: n
       !! Dimension of the matrix.
       real(dp), allocatable :: dv(:)
@@ -31,6 +32,7 @@ module SpecialMatrices_Tridiagonal
       !! Base type used to define a `Bidiagonal` matrix of size [n x n] with diagonals given by
       !! the rank-1 arrays `dv` and `ev`. The character `which` determines whether `ev` defines the
       !! sub-diagonal (`which = "L"`, default) or the super-diagonal (`which = "U"`).
+      private
       integer(ilp) :: n
       !! Dimension of the matrix.
       real(dp), allocatable :: dv(:), ev(:)
@@ -42,6 +44,7 @@ module SpecialMatrices_Tridiagonal
    type, public :: Tridiagonal
       !! Base type used to define a `Tridiagonal` matrix of size [n x n] with diagonal elements
       !! given by the rank-1 arrays `dl` (sub-diagonal), `d` (diagonal) and `du` (super-diagonal).
+      private
       integer(ilp) :: n
       !! Dimension of the matrix.
       real(dp), allocatable :: d(:), du(:), dl(:)
@@ -51,6 +54,7 @@ module SpecialMatrices_Tridiagonal
    type, public :: SymTridiagonal
       !! Base type used to define a `SymTridiagonal` matrix of size [n x n] with diagonal elements
       !! given by the rank-1 arrays `dv` (diagonal) and `ev` (sub- and super-diagonal).
+      private
       integer(ilp) :: n
       !! Dimension of the matrix.
       real(dp), allocatable :: dv(:), ev(:)

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -457,7 +457,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: x(:)
          !! Input vector.
-         real(dp) :: y(size(x))
+         real(dp), allocatable :: y(:)
          !! Output vector.
       end function diag_spmv
 
@@ -468,7 +468,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
          !! Input matrix (rank-2 array).
-         real(dp) :: Y(size(X, 1), size(X, 2))
+         real(dp), allocatable :: Y(:, :)
          !! Output matrix (rank-2 array).
       end function diag_multi_spmv
 
@@ -479,7 +479,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: x(:)
          !! Input vector.
-         real(dp) :: y(size(x))
+         real(dp), allocatable :: y(:)
          !! Output vector.
       end function bidiag_spmv
 
@@ -490,7 +490,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
          !! Input matrix (rank-2 array).
-         real(dp) :: Y(size(X, 1), size(X, 2))
+         real(dp), allocatable :: Y(:, :)
          !! Output matrix (rank-2 array).
       end function bidiag_multi_spmv
 
@@ -501,7 +501,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: x(:)
          !! Input vector.
-         real(dp) :: y(size(x))
+         real(dp), allocatable :: y(:)
          !! Output vector.
       end function tridiag_spmv
 
@@ -512,7 +512,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
          !! Input matrix (rank-2 array).
-         real(dp) :: Y(size(X, 1), size(X, 2))
+         real(dp), allocatable :: Y(:, :)
          !! Output matrix (rank-2 array).
       end function tridiag_multi_spmv
 
@@ -523,7 +523,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          real(dp), intent(in) :: x(:)
          !! Input vector.
-         real(dp) :: y(size(x))
+         real(dp), allocatable :: y(:)
          !! Output vector.
       end function symtridiag_spmv
 
@@ -532,7 +532,7 @@ module SpecialMatrices_Tridiagonal
          !! is of `SymTridiagonal` type and `X` and `Y` are both rank-2 arrays.
          type(SymTridiagonal), intent(in) :: A
          real(dp), intent(in) :: X(:, :)
-         real(dp) :: Y(size(X, 1), size(X, 2))
+         real(dp), allocatable :: Y(:, :)
       end function symtridiag_multi_spmv
    end interface
 

--- a/src/specialmatrices_tridiagonal_generic.f90
+++ b/src/specialmatrices_tridiagonal_generic.f90
@@ -40,7 +40,8 @@ contains
       !! Utility procedure to compute the matrix-vector product \( y = Ax \) where \( A \)
       !! is of `Tridiagonal` type and `x` and `y` are both rank-1 arrays.
       integer :: i, n
-      n = size(x); y(1) = A%d(1)*x(1) + A%du(1)*x(2)
+      n = size(x); allocate(y, mold=x)
+      y(1) = A%d(1)*x(1) + A%du(1)*x(2)
       do concurrent(i=2:n - 1)
          y(i) = A%dl(i-1)*x(i - 1) + A%d(i)*x(i) + A%du(i)*x(i + 1)
       end do
@@ -51,6 +52,7 @@ contains
       !! Utility procedure to compute the matrix-matrix product \( Y = AX \) where \( A \)
       !!  is of `Tridiagonal` type and `X` and `Y` are both rank-2 arrays.
       integer(ilp) :: i
+      allocate(Y, mold=X)
       do concurrent(i=1:size(X, 2))
          Y(:, i) = tridiag_spmv(A, X(:, i))
       end do

--- a/src/specialmatrices_tridiagonal_generic.f90
+++ b/src/specialmatrices_tridiagonal_generic.f90
@@ -9,153 +9,93 @@ contains
    !-----     Constructors     -----
    !--------------------------------
 
-   pure module function initialize_tridiag(n) result(A)
-      !! Utility function to construct a `Tridiagonal` matrix filled with zeros.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(Tridiagonal) :: A
-      !! Corresponding tridiagonal matrix.
+   module procedure initialize_tridiag
+      !! Utility procedure to construct a `Tridiagonal` matrix filled with zeros.
       A%n = n; allocate (A%d(n), A%du(n - 1), A%dl(n - 1))
       A%d = 0.0_dp; A%du = 0.0_dp; A%dl = 0.0_dp
       return
-   end function initialize_tridiag
+   end procedure initialize_tridiag
 
-   pure module function construct_tridiag(dl, d, du) result(A)
-      !! Utility function to construct a `Tridiagonal` matrix from rank-1 arrays.
-      real(dp), intent(in) :: dl(:), d(:), du(:)
-      !! Diagonal elements of the matrix.
-      type(Tridiagonal) :: A
-      !! Corresponding tridiagonal matrix.
+   module procedure construct_tridiag
+      !! Utility procedure to construct a `Tridiagonal` matrix from rank-1 arrays.
       A%n = size(d); A%dl = dl; A%d = d; A%du = du
-      return
-   end function construct_tridiag
+   end procedure construct_tridiag
 
-   pure module function construct_constant_tridiag(l, d, u, n) result(A)
-      !! Utility function to construct a `Tridiagonal` matrix with constant diagonals.
-      real(dp), intent(in) :: l, d, u
-      !! Constant diagonal elements of the matrix.
-      integer(ilp), intent(in) :: n
-      !! Dimension of the matrix.
-      type(Tridiagonal) :: A
-      !! Corresponding tridiagonal matrix.
+   module procedure construct_constant_tridiag
+      !! Utility procedure to construct a `Tridiagonal` matrix with constant diagonals.
       integer(ilp) :: i
       A%n = n; A%dl = [(l, i=1, n - 1)]; A%d = [(d, i=1, n)]; A%du = [(u, i=1, n - 1)]
-   end function construct_constant_tridiag
+   end procedure construct_constant_tridiag
 
-   module function construct_dense_to_tridiag(A) result(B)
-      !! Utility function to construct a `Tridiagonal` matrix from a rank-2 array.
-      real(dp), intent(in) :: A(:, :)
-      !! Dense [n x n] matrix from which to construct the `Tridiagonal` one.
-      type(Tridiagonal) :: B
-      !! Corresponding tridiagonal matrix.
+   module procedure construct_dense_to_tridiag
+      !! Utility procedure to construct a `Tridiagonal` matrix from a rank-2 array.
       B = Tridiagonal(diag(A, -1), diag(A), diag(A, 1))
-      return
-   end function construct_dense_to_tridiag
+   end procedure construct_dense_to_tridiag
 
    !------------------------------------------------------------
    !-----     Matrix-vector and Matrix-matrix products     -----
    !------------------------------------------------------------
 
-   pure module function tridiag_spmv(A, x) result(y)
-      !! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
+   module procedure tridiag_spmv
+      !! Utility procedure to compute the matrix-vector product \( y = Ax \) where \( A \)
       !! is of `Tridiagonal` type and `x` and `y` are both rank-1 arrays.
-      type(Tridiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: x(:)
-      !! Input vector.
-      real(dp) :: y(size(x))
-      !! Output vector.
       integer :: i, n
       n = size(x); y(1) = A%d(1)*x(1) + A%du(1)*x(2)
       do concurrent(i=2:n - 1)
          y(i) = A%dl(i-1)*x(i - 1) + A%d(i)*x(i) + A%du(i)*x(i + 1)
       end do
       y(n) = A%d(n)*x(n) + A%dl(n - 1)*x(n - 1)
-      return
-   end function tridiag_spmv
+   end procedure tridiag_spmv
 
-   pure module function tridiag_multi_spmv(A, X) result(Y)
-      !! Utility function to compute the matrix-matrix product \( Y = AX \) where \( A \)
+   module procedure tridiag_multi_spmv
+      !! Utility procedure to compute the matrix-matrix product \( Y = AX \) where \( A \)
       !!  is of `Tridiagonal` type and `X` and `Y` are both rank-2 arrays.
-      type(Tridiagonal), intent(in) :: A
-      !! Input matrix.
-      real(dp), intent(in) :: X(:, :)
-      !! Input matrix (rank-2 array).
-      real(dp) :: Y(size(X, 1), size(X, 2))
-      !! Output matrix (rank-2 array).
       integer(ilp) :: i
       do concurrent(i=1:size(X, 2))
          Y(:, i) = tridiag_spmv(A, X(:, i))
       end do
-      return
-   end function tridiag_multi_spmv
+   end procedure tridiag_multi_spmv
 
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
 
-   pure module function tridiag_solve(A, b) result(x)
-      !! Utility function to solve the linear system \( Ax = b \) where \( A \) is of
+   module procedure tridiag_solve
+      !! Utility procedure to solve the linear system \( Ax = b \) where \( A \) is of
       !! `Tridiagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
       !! with the same type and dimension as `b`.
-      type(Tridiagonal), intent(in) :: A
-      !! Coefficient matrix.
-      real(dp), intent(in) :: b(:)
-      !! Right-hand side vector.
-      real(dp) :: x(size(b))
-      !! Solution vector.
       integer :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
-
       ! Initialize arrays.
       n = A%n; dl = A%dl; d = A%d; du = A%du; b_(:, 1) = b ; nrhs = 1
-
       ! Solve the system.
       call gtsv(n, nrhs, dl, d, du, b_, n, info)
-
       ! Return the solution.
       x = b_(:, 1)
+   end procedure tridiag_solve
 
-      return
-   end function tridiag_solve
-
-   pure module function tridiag_multi_solve(A, B) result(X)
-      !! Utility function to solve a linear system with multiple right-hand sides where
+   module procedure tridiag_multi_solve
+      !! Utility procedure to solve a linear system with multiple right-hand sides where
       !! \( A \) is of `Tridiagonal` type and `B` a rank-2 array. The solution `X` is also
       !! a rank-2 array with the same type and dimensions as `B`.
-      type(Tridiagonal), intent(in) :: A
-      real(dp), intent(in) :: B(:, :)
-      real(dp) :: X(size(B, 1), size(B, 2))
       integer :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
-
       ! Initialize arrays.
       n = A%n; dl = A%dl; d = A%d; du = A%du; nrhs = size(B, 2); X = B
-
       ! Solve the systems.
       call gtsv(n, nrhs, dl, d, du, X, n, info)
-
-   end function tridiag_multi_solve
+   end procedure tridiag_multi_solve
 
    !-------------------------------------
-   !-----     Utility functions     -----
+   !-----     Utility procedures     -----
    !-------------------------------------
 
-   pure module function tridiag_shape(A) result(shape)
-      type(Tridiagonal), intent(in) :: A
-      !! Input matrix.
-      integer(ilp) :: shape(2)
-      !! Shape of the matrix.
+   module procedure tridiag_shape
       shape = A%n
-      return
-   end function tridiag_shape
+   end procedure tridiag_shape
 
-   pure module function tridiag_to_dense(A) result(B)
-      !! Utility function to convert a `Tridiagonal` matrix to a regular rank-2 array.
-      type(Tridiagonal), intent(in) :: A
-      !! Input tridiagonal matrix.
-      real(dp) :: B(A%n, A%n)
-      !! Output dense rank-2 array.
+   module procedure tridiag_to_dense
+      !! Utility procedure to convert a `Tridiagonal` matrix to a regular rank-2 array.
       integer :: i, n
       n = A%n; B = 0.0_dp
       B(1, 1) = A%d(1); B(1, 2) = A%du(1)
@@ -165,17 +105,12 @@ contains
          B(i, i + 1) = A%du(i)
       end do
       B(n, n - 1) = A%dl(n - 1); B(n, n) = A%d(n)
-      return
-   end function tridiag_to_dense
+   end procedure tridiag_to_dense
 
-   pure module function tridiag_transpose(A) result(B)
-      !! Utility function to compute the transpose of a `Tridiagonal` matrix.
+   module procedure tridiag_transpose
+      !! Utility procedure to compute the transpose of a `Tridiagonal` matrix.
       !! The output matrix is also of `Tridiagonal` type.
-      type(Tridiagonal), intent(in) :: A
-      !! Input tridiagonal matrix.
-      type(Tridiagonal) :: B
-      !! Transpose of the original tridiagonal matrix.
       B = A; B%dl = A%du; B%du = A%dl
-   end function tridiag_transpose
+   end procedure tridiag_transpose
 
 end submodule GenericTridiagonal

--- a/src/specialmatrices_tridiagonal_generic.f90
+++ b/src/specialmatrices_tridiagonal_generic.f90
@@ -39,7 +39,7 @@ contains
    module procedure tridiag_spmv
       !! Utility procedure to compute the matrix-vector product \( y = Ax \) where \( A \)
       !! is of `Tridiagonal` type and `x` and `y` are both rank-1 arrays.
-      integer :: i, n
+      integer(ilp) :: i, n
       n = size(x); allocate(y, mold=x)
       y(1) = A%d(1)*x(1) + A%du(1)*x(2)
       do concurrent(i=2:n - 1)
@@ -66,7 +66,7 @@ contains
       !! Utility procedure to solve the linear system \( Ax = b \) where \( A \) is of
       !! `Tridiagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
       !! with the same type and dimension as `b`.
-      integer :: i, n, nrhs, info
+      integer(ilp) :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
       ! Initialize arrays.
       n = A%n; dl = A%dl; d = A%d; du = A%du; b_(:, 1) = b ; nrhs = 1
@@ -80,7 +80,7 @@ contains
       !! Utility procedure to solve a linear system with multiple right-hand sides where
       !! \( A \) is of `Tridiagonal` type and `B` a rank-2 array. The solution `X` is also
       !! a rank-2 array with the same type and dimensions as `B`.
-      integer :: i, n, nrhs, info
+      integer(ilp) :: i, n, nrhs, info
       real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
       ! Initialize arrays.
       n = A%n; dl = A%dl; d = A%d; du = A%du; nrhs = size(B, 2); X = B
@@ -98,7 +98,7 @@ contains
 
    module procedure tridiag_to_dense
       !! Utility procedure to convert a `Tridiagonal` matrix to a regular rank-2 array.
-      integer :: i, n
+      integer(ilp) :: i, n
       n = A%n; B = 0.0_dp
       B(1, 1) = A%d(1); B(1, 2) = A%du(1)
       do concurrent(i=2:n - 1)

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -116,7 +116,7 @@ contains
 
         ! Initialize matrix.
         call random_number(dv); call random_number(ev)
-        A = Bidiagonal(dv, ev)
+        A = Bidiagonal(dv, ev, which="L")
 
         ! Matrix-vector product with A lower bidiagonal.
         block
@@ -126,15 +126,15 @@ contains
         call check(error, all_close(y, y_dense), &
         "Lower-bidiagonal matrix-vector product failed.")
         if (allocated(error)) return
-
-        A%which = "U"
+        ! Matrix-vector product wih A upper bidiaognal.
+        A = Bidiagonal(dv, ev, which="U")
         y = matmul(A, x); y_dense = matmul(dense(A), x)
         call check(error, all_close(y, y_dense), &
         "Upper-bidiagonal matrix-vector product failed.")
         if (allocated(error)) return
         end block
 
-        ! Matrix-matrix product with A lower bidiagonal.
+        ! Matrix-matrix product with A upper bidiagonal.
         block
         real(dp) :: x(n, n), y(n, n), y_dense(n, n)
         call random_number(x)
@@ -142,8 +142,8 @@ contains
         call check(error, all_close(y, y_dense), &
         "Upper-bidiagonal matrix-matrix product failed.")
         if (allocated(error)) return
-
-        A%which = "L"
+        ! Matrix-matrix product with A lower bidiagonal.
+        A = Bidiagonal(dv, ev, which="L")
         y = matmul(A, x); y_dense = matmul(dense(A), x)
         call check(error, all_close(y, y_dense), &
         "Lower-bidiagonal matrix-matrix product failed.")
@@ -158,7 +158,7 @@ contains
 
         ! Initialize matrix.
         call random_number(ev); call random_number(dv)
-        A = Bidiagonal(dv, ev)
+        A = Bidiagonal(dv, ev, which="L")
 
         ! Solve with a singe right-hand side vector.
         block
@@ -174,7 +174,7 @@ contains
         "Lower-bidiagonal solve with a single rhs failed.")
         if (allocated(error)) return
 
-        A%which = "U"
+        A = Bidiagonal(dv, ev, which="U")
         ! Solve with SpecialMatrices.
         x = solve(A, b)
         ! Solve with stdlib (dense).
@@ -198,7 +198,7 @@ contains
         "Upper-bidiagonal solve with multiple rhs failed.")
         if(allocated(error)) return
 
-        A%which = "L"
+        A = Bidiagonal(dv, ev, which="L")
         ! Solve with SpecialMatrices.
         x = solve(A, b)
         ! Solve with stdlib (dense).


### PR DESCRIPTION
- Remove functions signatures from Diagonal submodule and make use of procedure.
- Remove function signature and use procedure for Bidiagonal module.
- Remove function signature and use procedure for SymTridiagonal module.
- Remove function signature and use procedure for Tridiagonal module.
- Data encapsulation for each type (private).
- Made spmv return vector allocatable by default.
- Made solution in solve allocatable by default.
