### PR TITLE
Feature-complete `Diagonal` matrices.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ["/fpp /O3"]}
           # - os: windows-latest
           #   toolchain: {compiler: intel, version: '2024.1', flags: ["/fpp /O3"]}
-          - os: macos-12
+          - os: macos-latest
             toolchain: {compiler: gcc, version: 13, flags: ['-cpp -O3 -march=native -mtune=native']}
           # - os: macos-12
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ['-fpp -O3 -xhost']}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ["/fpp /O3"]}
           # - os: windows-latest
           #   toolchain: {compiler: intel, version: '2024.1', flags: ["/fpp /O3"]}
-          - os: macos-latest
+          - os: macos-13
             toolchain: {compiler: gcc, version: 13, flags: ['-cpp -O3 -march=native -mtune=native']}
           # - os: macos-12
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ['-fpp -O3 -xhost']}

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -20,7 +20,7 @@ module SpecialMatrices
    public :: det
    public :: trace
    public :: inv
-   public :: matmul
+   public :: matmul, spmv_ip
    public :: solve
 
    !-------------------------------------

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -21,7 +21,7 @@ module SpecialMatrices
    public :: trace
    public :: inv
    public :: matmul, spmv_ip
-   public :: solve
+   public :: solve, solve_ip
 
    !-------------------------------------
    !-----     Utility functions     -----

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -17,6 +17,8 @@ module SpecialMatrices
    !----------------------------------
 
    public :: transpose
+   public :: det
+   public :: trace
    public :: matmul
    public :: solve
 

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -19,6 +19,7 @@ module SpecialMatrices
    public :: transpose
    public :: det
    public :: trace
+   public :: inv
    public :: matmul
    public :: solve
 

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -23,6 +23,7 @@ module SpecialMatrices
    public :: matmul, spmv_ip
    public :: solve, solve_ip
    public :: svd, svdvals
+   public :: eigvalsh
 
    !-------------------------------------
    !-----     Utility functions     -----

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -23,7 +23,7 @@ module SpecialMatrices
    public :: matmul, spmv_ip
    public :: solve, solve_ip
    public :: svd, svdvals
-   public :: eigvalsh
+   public :: eigh, eigvalsh
 
    !-------------------------------------
    !-----     Utility functions     -----

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -22,6 +22,7 @@ module SpecialMatrices
    public :: inv
    public :: matmul, spmv_ip
    public :: solve, solve_ip
+   public :: svd, svdvals
 
    !-------------------------------------
    !-----     Utility functions     -----

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -29,6 +29,7 @@ module SpecialMatrices
 
    public :: dense
    public :: shape
+   public :: size
 
    public :: say_hello
 contains

--- a/src/specialmatrices_bidiagonal.f90
+++ b/src/specialmatrices_bidiagonal.f90
@@ -10,21 +10,21 @@ contains
    !--------------------------------
 
    module procedure initialize_bidiag
-      ! Utility procedure to construct a `Bidiagonal` matrix filled with zeros.
-      A%n = n; A%which = optval(which, "L")
-      allocate(A%dv(n), A%ev(n-1)); A%dv = 0.0_dp; A%ev = 0.0_dp
+   ! Utility procedure to construct a `Bidiagonal` matrix filled with zeros.
+   A%n = n; A%which = optval(which, "L")
+   allocate (A%dv(n), A%ev(n - 1)); A%dv = 0.0_dp; A%ev = 0.0_dp
    end procedure initialize_bidiag
 
    module procedure construct_bidiag
       !! Utility procedure to construct a `Bidiagonal` matrix from rank-1 arrays.
-      A%n = size(dv); A%dv = dv ; A%ev = ev ; A%which = optval(which, "L")
+   A%n = size(dv); A%dv = dv; A%ev = ev; A%which = optval(which, "L")
    end procedure construct_bidiag
 
    module procedure construct_constant_bidiag
       !! Utility procedure to construct a `Bidiagonal` matrix with constant elements.
-      integer(ilp) :: i
-      A%n = n; A%which = optval(which, "L")
-      A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
+   integer(ilp) :: i
+   A%n = n; A%which = optval(which, "L")
+   A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n - 1)]
    end procedure construct_constant_bidiag
 
    !------------------------------------------------------------
@@ -32,27 +32,27 @@ contains
    !------------------------------------------------------------
 
    module procedure bidiag_spmv
-      integer(ilp) :: i, n
-      n = size(x); allocate(y, mold=x)
-      if (A%which == "L") then
-         y(1) = A%dv(1) * x(1)
-         do concurrent (i=2:n)
-            y(i) = A%ev(i-1)*x(i-1) + A%dv(i)*x(i)
-         enddo
-      elseif (A%which == "U") then
-         do concurrent (i=1:n-1)
-            y(i) = A%dv(i)*x(i) + A%ev(i)*x(i+1)
-         enddo
-         y(n) = A%dv(n) * x(n)
-      endif
+   integer(ilp) :: i, n
+   n = size(x); allocate (y, mold=x)
+   if (A%which == "L") then
+      y(1) = A%dv(1)*x(1)
+      do concurrent(i=2:n)
+         y(i) = A%ev(i - 1)*x(i - 1) + A%dv(i)*x(i)
+      end do
+   elseif (A%which == "U") then
+      do concurrent(i=1:n - 1)
+         y(i) = A%dv(i)*x(i) + A%ev(i)*x(i + 1)
+      end do
+      y(n) = A%dv(n)*x(n)
+   end if
    end procedure bidiag_spmv
 
    module procedure bidiag_multi_spmv
-      integer(ilp) :: i, n
-      n = size(x); allocate(Y, mold=X)
-      do concurrent (i=1:size(X, 2))
-         Y(:, i) = bidiag_spmv(A, X(:, i))
-      enddo
+   integer(ilp) :: i, n
+   n = size(x); allocate (Y, mold=X)
+   do concurrent(i=1:size(X, 2))
+      Y(:, i) = bidiag_spmv(A, X(:, i))
+   end do
    end procedure bidiag_multi_spmv
 
    !----------------------------------
@@ -60,35 +60,35 @@ contains
    !----------------------------------
 
    module procedure bidiag_solve
-      real(dp) :: dl(A%n-1), dv(A%n), du(A%n-1), b_(A%n, 1)
-      integer(ilp) :: n, nrhs, info
-      ! Initialize array.
-      n = A%n; b_(:, 1) = b; nrhs = 1; dv = A%dv
-      ! Dispatch based on upper- or lower-bidiagonal.
-      if (A%which == "L") then
-         dl = A%ev; du = 0.0_dp
-      elseif (A%which == "U") then
-         dl = 0.0_dp; du = A%ev
-      endif
-      ! Solve the system using a tridiagonal solver.
-      call gtsv(n, nrhs, dl, dv, du, b_, n, info)
-      ! Return the solution.
-      x = b_(:, 1)
+   real(dp) :: dl(A%n - 1), dv(A%n), du(A%n - 1), b_(A%n, 1)
+   integer(ilp) :: n, nrhs, info
+   ! Initialize array.
+   n = A%n; b_(:, 1) = b; nrhs = 1; dv = A%dv
+   ! Dispatch based on upper- or lower-bidiagonal.
+   if (A%which == "L") then
+      dl = A%ev; du = 0.0_dp
+   elseif (A%which == "U") then
+      dl = 0.0_dp; du = A%ev
+   end if
+   ! Solve the system using a tridiagonal solver.
+   call gtsv(n, nrhs, dl, dv, du, b_, n, info)
+   ! Return the solution.
+   x = b_(:, 1)
    end procedure bidiag_solve
 
    module procedure bidiag_multi_solve
-      real(dp) :: dl(A%n-1), dv(A%n), du(A%n-1), b_(A%n, 1)
-      integer(ilp) :: n, nrhs, info
-      ! Initialize array.
-      n = A%n; X = B; nrhs = size(X, 2); dv = A%dv
-      ! Dispatch based on upper- or lower-bidiagonal.
-      if (A%which == "L") then
-         dl = A%ev; du = 0.0_dp
-      elseif (A%which == "U") then
-         dl = 0.0_dp; du = A%ev
-      endif
-      ! Solve the system using a tridiagonal solver.
-      call gtsv(n, nrhs, dl, dv, du, X, n, info)
+   real(dp) :: dl(A%n - 1), dv(A%n), du(A%n - 1), b_(A%n, 1)
+   integer(ilp) :: n, nrhs, info
+   ! Initialize array.
+   n = A%n; X = B; nrhs = size(X, 2); dv = A%dv
+   ! Dispatch based on upper- or lower-bidiagonal.
+   if (A%which == "L") then
+      dl = A%ev; du = 0.0_dp
+   elseif (A%which == "U") then
+      dl = 0.0_dp; du = A%ev
+   end if
+   ! Solve the system using a tridiagonal solver.
+   call gtsv(n, nrhs, dl, dv, du, X, n, info)
    end procedure bidiag_multi_solve
 
    !------------------------------------
@@ -96,34 +96,34 @@ contains
    !------------------------------------
 
    module procedure bidiag_shape
-      shape = A%n
+   shape = A%n
    end procedure bidiag_shape
 
    module procedure bidiag_transpose
-      B = A
-      if (A%which == "L") then
-         B%which = "U"
-      else
-         B%which = "L"
-      endif
+   B = A
+   if (A%which == "L") then
+      B%which = "U"
+   else
+      B%which = "L"
+   end if
    end procedure bidiag_transpose
 
    module procedure bidiag_to_dense
-      integer(ilp) :: i, n
-      n = A%n; B = 0.0_dp
-      if (A%which == "L") then
-         B(1, 1) = A%dv(1)
-         do concurrent(i=2:n)
-            B(i, i) = A%dv(i)
-            B(i, i-1) = A%ev(i-1)
-         enddo
-      elseif (A%which == "U") then
-         do concurrent(i=1:n-1)
-            B(i, i) = A%dv(i)
-            B(i, i+1) = A%ev(i)
-         enddo
-         B(n, n) = A%dv(n)
-      endif
+   integer(ilp) :: i, n
+   n = A%n; B = 0.0_dp
+   if (A%which == "L") then
+      B(1, 1) = A%dv(1)
+      do concurrent(i=2:n)
+         B(i, i) = A%dv(i)
+         B(i, i - 1) = A%ev(i - 1)
+      end do
+   elseif (A%which == "U") then
+      do concurrent(i=1:n - 1)
+         B(i, i) = A%dv(i)
+         B(i, i + 1) = A%ev(i)
+      end do
+      B(n, n) = A%dv(n)
+   end if
    end procedure bidiag_to_dense
 
 end submodule BidiagonalMatrices

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -120,4 +120,9 @@ contains
    shape = A%n
    end procedure diag_shape
 
+   module procedure diag_size
+   ! Utility function to get the size of a `Diagonal` matrix along a given dimension.
+   arr_size = A%n
+   end procedure diag_size
+
 end submodule DiagonalMatrices

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -98,6 +98,30 @@ contains
    end do
    end procedure diag_multi_solve
 
+   module procedure diag_solve_ip
+   ! Utility function to solve *in-place* a linear system with multiple right-hande sides where
+   ! \( A \) is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
+   ! with the same type and dimensions as `B`.
+   integer(ilp) :: i
+   do concurrent(i=1:A%n)
+      x(i) = b(i)/A%dv(i)
+   end do
+   return
+   end procedure diag_solve_ip
+
+   module procedure diag_multi_solve_ip
+   ! Utility function to solve a linear system with multiple right-hande sides where \( A \)
+   ! is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
+   ! with the same type and dimensions as `B`.
+   integer(ilp) :: i, j
+   real(dp) :: inv_dv(A%n)
+   inv_dv = 1.0_dp/A%dv
+   do concurrent(i=1:A%n, j=1:size(B, 2))
+      X(i, j) = inv_dv(i)*B(i, j)
+   end do
+   return
+   end procedure diag_multi_solve_ip
+
    module procedure diag_det
    ! Utility function to compute the determinant of a `Diagonal` matrix \( A \).
    determinant = product(A%dv)

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -82,9 +82,15 @@ contains
    end do
    end procedure diag_multi_solve
 
-   module procedure diag_eig
-   lambda = A%dv; vectors = eye(A%n)
-   end procedure diag_eig
+   module procedure diag_det
+   ! Utility function to compute the determinant of a `Diagonal` matrix \( A \).
+   determinant = product(A%dv)
+   end procedure diag_det
+
+   module procedure diag_trace
+   ! Utility function to compute the trace of a `Diagonal` matrix \( A \).
+   tr = sum(A%dv)
+   end procedure diag_trace
 
    !------------------------------------
    !-----     Utility function     -----

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -158,6 +158,11 @@ contains
    vt = vt(index, :)
    end procedure diag_svd
 
+   module procedure diag_eigvalsh
+   ! Utility function to compute the eigenvalues of a real `Diagonal` matrix \( A \).
+   lambda = A%dv; call sort(lambda)
+   end procedure diag_eigvalsh
+
    !------------------------------------
    !-----     Utility function     -----
    !------------------------------------

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -163,6 +163,16 @@ contains
    lambda = A%dv; call sort(lambda)
    end procedure diag_eigvalsh
 
+   module procedure diag_eigh
+   ! Utility function to compute the eigenvalues and eigenvectors of a real `Diagonal`
+   ! matrix \( A \).
+   integer(ilp) :: index(A%n)
+   lambda = A%dv; call sort_index(lambda, index)
+   if (present(vectors)) then
+      vectors = eye(A%n); vectors = vectors(:, index)
+   end if
+   end procedure diag_eigh
+
    !------------------------------------
    !-----     Utility function     -----
    !------------------------------------

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -1,5 +1,6 @@
 submodule(SpecialMatrices_Tridiagonal) DiagonalMatrices
    use stdlib_linalg, only: eye, diag
+   use stdlib_sorting, only: sort, sort_index
    use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling, LINALG_VALUE_ERROR, &
                                   LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR
    implicit none(type, external)
@@ -136,6 +137,26 @@ contains
    ! Utility function to compute the inverse of a `Diagonal` matrix \( A \).
    B = dense(Diagonal(1.0_dp/A%dv))
    end procedure diag_inv
+
+   module procedure diag_svdvals
+   ! Utility function to compute the singular values of a `Diagonal` matrix \( A \).
+   s = abs(A%dv); call sort(s, reverse=.true.)
+   end procedure diag_svdvals
+
+   module procedure diag_svd
+   ! Utility function to compute the singular values of a `Diagonal` matrix \( A \).
+   integer(ilp) :: i, index(A%n)
+   ! Compute the singular values and sort them in decreasing order.
+   s = abs(A%dv); call sort_index(s, index, reverse=.true.)
+   ! Compute the left singular vectors.
+   u = eye(A%n); u = u(:, index)
+   ! Compute the right singular vectors.
+   vt = eye(A%n); 
+   do concurrent(i=1:A%n, A%dv(i) < 0.0_dp)
+      vt(i, i) = -1.0_dp
+   end do
+   vt = vt(index, :)
+   end procedure diag_svd
 
    !------------------------------------
    !-----     Utility function     -----

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -92,6 +92,11 @@ contains
    tr = sum(A%dv)
    end procedure diag_trace
 
+   module procedure diag_inv
+   ! Utility function to compute the inverse of a `Diagonal` matrix \( A \).
+   B = dense(Diagonal(1.0_dp / A%dv))
+   end procedure diag_inv
+
    !------------------------------------
    !-----     Utility function     -----
    !------------------------------------

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -55,6 +55,22 @@ contains
    end do
    end procedure diag_multi_spmv
 
+   module procedure diag_spmv_ip
+   integer(ilp) :: i
+   do concurrent(i=1:size(x))
+      y(i) = A%dv(i)*x(i)
+   end do
+   return
+   end procedure diag_spmv_ip
+
+   module procedure diag_multi_spmv_ip
+   integer(ilp) :: i, j
+   do concurrent(i=1:size(X, 1), j=1:size(X, 2))
+      Y(i, j) = A%dv(i)*X(i, j)
+   end do
+   return
+   end procedure diag_multi_spmv_ip
+
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
@@ -94,7 +110,7 @@ contains
 
    module procedure diag_inv
    ! Utility function to compute the inverse of a `Diagonal` matrix \( A \).
-   B = dense(Diagonal(1.0_dp / A%dv))
+   B = dense(Diagonal(1.0_dp/A%dv))
    end procedure diag_inv
 
    !------------------------------------
@@ -104,7 +120,7 @@ contains
    module procedure diag_to_dense
    ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
    integer(ilp) :: i
-   allocate(B(A%n, A%n)); B = 0.0_dp
+   allocate (B(A%n, A%n)); B = 0.0_dp
    do concurrent(i=1:A%n)
       B(i, i) = A%dv(i)
    end do

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -104,7 +104,7 @@ contains
    module procedure diag_to_dense
    ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
    integer(ilp) :: i
-   B = 0.0_dp
+   allocate(B(A%n, A%n)); B = 0.0_dp
    do concurrent(i=1:A%n)
       B(i, i) = A%dv(i)
    end do

--- a/src/specialmatrices_diagonal.f90
+++ b/src/specialmatrices_diagonal.f90
@@ -1,7 +1,7 @@
 submodule(SpecialMatrices_Tridiagonal) DiagonalMatrices
    use stdlib_linalg, only: eye, diag
    use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling, LINALG_VALUE_ERROR, &
-      LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR
+                                  LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR
    implicit none(type, external)
 
 contains
@@ -11,24 +11,24 @@ contains
    !--------------------------------
 
    module procedure initialize_diag
-      ! Utility function to construct a `Diagonal` matrix filled with zeros.
-      A%n = n; allocate(A%dv(n)); A%dv = 0.0_dp
+   ! Utility function to construct a `Diagonal` matrix filled with zeros.
+   A%n = n; allocate (A%dv(n)); A%dv = 0.0_dp
    end procedure initialize_diag
 
    module procedure construct_diag
-      ! Utility function to construct a `Diagonal` matrix from a rank-1 array.
-      A%n = size(dv); A%dv = dv
+   ! Utility function to construct a `Diagonal` matrix from a rank-1 array.
+   A%n = size(dv); A%dv = dv
    end procedure construct_diag
 
    module procedure construct_constant_diag
-      ! Utility function to construct a `Diagonal` matrix with constant diagonal element.
-      integer(ilp) :: i
-      A%n = n; A%dv = [(d, i=1, n)]
+   ! Utility function to construct a `Diagonal` matrix with constant diagonal element.
+   integer(ilp) :: i
+   A%n = n; A%dv = [(d, i=1, n)]
    end procedure construct_constant_diag
 
    module procedure construct_dense_to_diag
-      ! Utility function to construct a `Diagonal` matrix from a rank-2 array.
-      B = Diagonal(diag(A))
+   ! Utility function to construct a `Diagonal` matrix from a rank-2 array.
+   B = Diagonal(diag(A))
    end procedure construct_dense_to_diag
 
    !------------------------------------------------------------
@@ -36,23 +36,23 @@ contains
    !------------------------------------------------------------
 
    module procedure diag_spmv
-      ! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
-      ! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
-      integer(ilp) :: i
-      allocate(y, mold=x)
-      do concurrent(i=1:size(x))
-         y(i) = A%dv(i) * x(i)
-      enddo
+   ! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
+   ! is of `Diagonal` type and `x` and `y` are both rank-1 arrays.
+   integer(ilp) :: i
+   allocate (y, mold=x)
+   do concurrent(i=1:size(x))
+      y(i) = A%dv(i)*x(i)
+   end do
    end procedure diag_spmv
 
    module procedure diag_multi_spmv
-      ! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
-      ! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
-      integer(ilp) :: i, j
-      allocate(Y, mold=X)
-      do concurrent(i=1:size(X, 1), j=1:size(X, 2))
-         Y(i, j) = A%dv(i) * X(i, j)
-      enddo
+   ! Utility function to compute the matrix-vector product \( y = A x \) where \( A \)
+   ! is of `Diagonal` type and `X` and `Y` are both rank-2 arrays.
+   integer(ilp) :: i, j
+   allocate (Y, mold=X)
+   do concurrent(i=1:size(X, 1), j=1:size(X, 2))
+      Y(i, j) = A%dv(i)*X(i, j)
+   end do
    end procedure diag_multi_spmv
 
    !----------------------------------
@@ -60,30 +60,30 @@ contains
    !----------------------------------
 
    module procedure diag_solve
-      ! Utility function to solve the linear system \( A x = b \) where \( A \) is of
-      ! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
-      ! with the same type and dimension of `b`.
-      integer(ilp) :: i, n
-      allocate(x, mold=b)
-      do concurrent(i=1:A%n)
-         x(i) = b(i) / A%dv(i)
-      enddo
+   ! Utility function to solve the linear system \( A x = b \) where \( A \) is of
+   ! `Diagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
+   ! with the same type and dimension of `b`.
+   integer(ilp) :: i, n
+   allocate (x, mold=b)
+   do concurrent(i=1:A%n)
+      x(i) = b(i)/A%dv(i)
+   end do
    end procedure diag_solve
 
    module procedure diag_multi_solve
-      ! Utility function to solve a linear system with multiple right-hande sides where \( A \)
-      ! is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
-      ! with the same type and dimensions as `B`.
-      integer(ilp) :: i, j
-      real(dp) :: inv_dv(A%n)
-      allocate(X, mold=B); inv_dv = 1.0_dp / A%dv
-      do concurrent(i=1:A%n, j=1:size(B, 2))
-         X(i, j) = B(i, j) * inv_dv(i)
-      enddo
+   ! Utility function to solve a linear system with multiple right-hande sides where \( A \)
+   ! is of `Diagonal` type and `B` a rank-2 array. The solution `X` is also a rank-2 array
+   ! with the same type and dimensions as `B`.
+   integer(ilp) :: i, j
+   real(dp) :: inv_dv(A%n)
+   allocate (X, mold=B); inv_dv = 1.0_dp/A%dv
+   do concurrent(i=1:A%n, j=1:size(B, 2))
+      X(i, j) = B(i, j)*inv_dv(i)
+   end do
    end procedure diag_multi_solve
 
    module procedure diag_eig
-      lambda = A%dv ; vectors = eye(A%n)
+   lambda = A%dv; vectors = eye(A%n)
    end procedure diag_eig
 
    !------------------------------------
@@ -91,22 +91,22 @@ contains
    !------------------------------------
 
    module procedure diag_to_dense
-      ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
-      integer(ilp) :: i
-      B = 0.0_dp
-      do concurrent(i=1:A%n)
-         B(i, i) = A%dv(i)
-      enddo
+   ! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
+   integer(ilp) :: i
+   B = 0.0_dp
+   do concurrent(i=1:A%n)
+      B(i, i) = A%dv(i)
+   end do
    end procedure diag_to_dense
 
    module procedure diag_transpose
-      ! Utility function to compute the transpose of a `Diagonal` matrix.
-      B = A
+   ! Utility function to compute the transpose of a `Diagonal` matrix.
+   B = A
    end procedure diag_transpose
 
    module procedure diag_shape
-      ! Utility function to get the shape of a `Diagonal` matrix.
-      shape = A%n
+   ! Utility function to get the shape of a `Diagonal` matrix.
+   shape = A%n
    end procedure diag_shape
-   
+
 end submodule DiagonalMatrices

--- a/src/specialmatrices_symtridiagonal.f90
+++ b/src/specialmatrices_symtridiagonal.f90
@@ -9,17 +9,17 @@ contains
    !--------------------------------
 
    module procedure initialize_symtridiag
-      A%n = n; allocate(A%dv(n), A%ev(n-1))
-      A%dv = 0.0_dp; A%ev = 0.0_dp
+   A%n = n; allocate (A%dv(n), A%ev(n - 1))
+   A%dv = 0.0_dp; A%ev = 0.0_dp
    end procedure initialize_symtridiag
 
    module procedure construct_symtridiag
-      A%n = size(dv); A%dv = dv; A%ev = ev
+   A%n = size(dv); A%dv = dv; A%ev = ev
    end procedure construct_symtridiag
 
    module procedure construct_constant_symtridiag
-      integer(ilp) :: i
-      A%n = n; A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n-1)]
+   integer(ilp) :: i
+   A%n = n; A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n - 1)]
    end procedure construct_constant_symtridiag
 
    !------------------------------------------------------------
@@ -27,21 +27,21 @@ contains
    !------------------------------------------------------------
 
    module procedure symtridiag_spmv
-      integer(ilp) :: i, n
-      n = size(x); allocate(y, mold=x)
-      y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
-      do concurrent (i=2:n-1)
-         y(i) = A%ev(i-1)*x(i-1) + A%dv(i)*x(i) + A%ev(i)*x(i+1)
-      enddo
-      y(n) = A%dv(n)*x(n) + A%ev(n-1)*x(n-1)
+   integer(ilp) :: i, n
+   n = size(x); allocate (y, mold=x)
+   y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
+   do concurrent(i=2:n - 1)
+      y(i) = A%ev(i - 1)*x(i - 1) + A%dv(i)*x(i) + A%ev(i)*x(i + 1)
+   end do
+   y(n) = A%dv(n)*x(n) + A%ev(n - 1)*x(n - 1)
    end procedure symtridiag_spmv
 
    module procedure symtridiag_multi_spmv
-      integer(ilp) :: i
-      allocate(Y, mold=X)
-      do concurrent(i=1:size(X,2))
-         Y(:, i) = symtridiag_spmv(A, X(:, i))
-      enddo
+   integer(ilp) :: i
+   allocate (Y, mold=X)
+   do concurrent(i=1:size(X, 2))
+      Y(:, i) = symtridiag_spmv(A, X(:, i))
+   end do
    end procedure symtridiag_multi_spmv
 
    !----------------------------------
@@ -49,23 +49,23 @@ contains
    !----------------------------------
 
    module procedure symtridiag_solve
-      integer(ilp) :: i, n, nrhs, info
-      real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
-      ! Initialize arrays.
-      n = A%n; dl = A%ev; d = A%dv; du = A%ev; b_(:, 1) = b ; nrhs = 1
-      ! Solve the system.
-      call gtsv(n, nrhs, dl, d, du, b_, n, info)
-      ! Return the solution.
-      x = b_(:, 1)
+   integer(ilp) :: i, n, nrhs, info
+   real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
+   ! Initialize arrays.
+   n = A%n; dl = A%ev; d = A%dv; du = A%ev; b_(:, 1) = b; nrhs = 1
+   ! Solve the system.
+   call gtsv(n, nrhs, dl, d, du, b_, n, info)
+   ! Return the solution.
+   x = b_(:, 1)
    end procedure symtridiag_solve
 
    module procedure symtridiag_multi_solve
-      integer(ilp) :: i, n, nrhs, info
-      real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
-      ! Initialize arrays.
-      n = A%n; dl = A%ev; d = A%dv; du = A%ev; nrhs = size(B, 2); X = B
-      ! Solve the systems.
-      call gtsv(n, nrhs, dl, d, du, X, n, info)
+   integer(ilp) :: i, n, nrhs, info
+   real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
+   ! Initialize arrays.
+   n = A%n; dl = A%ev; d = A%dv; du = A%ev; nrhs = size(B, 2); X = B
+   ! Solve the systems.
+   call gtsv(n, nrhs, dl, d, du, X, n, info)
    end procedure symtridiag_multi_solve
 
    !-------------------------------------
@@ -73,23 +73,23 @@ contains
    !-------------------------------------
 
    module procedure symtridiag_to_dense
-      integer(ilp) :: i, n
-      n = A%n; B = 0.0_dp
-      B(1, 1) = A%dv(1); B(1, 2) = A%ev(1)
-      do concurrent(i=2:n - 1)
-         B(i, i - 1) = A%ev(i - 1)
-         B(i, i) = A%dv(i)
-         B(i, i + 1) = A%ev(i)
-      end do
-      B(n, n - 1) = A%ev(n - 1); B(n, n) = A%dv(n)
+   integer(ilp) :: i, n
+   n = A%n; B = 0.0_dp
+   B(1, 1) = A%dv(1); B(1, 2) = A%ev(1)
+   do concurrent(i=2:n - 1)
+      B(i, i - 1) = A%ev(i - 1)
+      B(i, i) = A%dv(i)
+      B(i, i + 1) = A%ev(i)
+   end do
+   B(n, n - 1) = A%ev(n - 1); B(n, n) = A%dv(n)
    end procedure symtridiag_to_dense
 
    module procedure symtridiag_transpose
-      B = A
+   B = A
    end procedure symtridiag_transpose
 
    module procedure symtridiag_shape
-      shape(2) = A%n
+   shape(2) = A%n
    end procedure symtridiag_shape
 
 end submodule SymmetricTridiagonal

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -12,7 +12,7 @@ module SpecialMatrices_Tridiagonal
    public :: matmul, spmv_ip
    public :: solve, solve_ip
    public :: svd, svdvals
-   public :: eigvalsh
+   public :: eigh, eigvalsh
 
    ! --> Utility functions.
    public :: dense
@@ -910,7 +910,7 @@ module SpecialMatrices_Tridiagonal
       !!
       !! #### Arguments
       !!
-      !! `A`   :  `real-valued matrix of `Diagonal` or `SymTridiagonal` type.
+      !! `A`   :  `real`-valued matrix of `Diagonal` or `SymTridiagonal` type.
       !!          It is an `intent(in)` argument.
       !!
       !! `lambda` :  Vector of eigenvalues in increasing order.
@@ -921,6 +921,38 @@ module SpecialMatrices_Tridiagonal
          real(dp), allocatable :: lambda(:)
          !! Eigenvalues.
       end function diag_eigvalsh
+   end interface
+
+   interface eigh
+      !! This interface overloads the `eigh` interface from `stdlib_linalg` to compute the
+      !! eigenvalues and eigenvectors of a real-valued matrix \(A\) whose type is `Diagonal`
+      !! or `SymTridiagonal`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    call eigh(A, lambda [, vectors])
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   : `real`-valued matrix of `Diagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `lambda` :  Rank-1 `real` array returning the eigenvalues of `A` in increasing order.
+      !!             It is an `intent(out)` argument.
+      !!
+      !! `vectors` (optional) :  Rank-2 array of the same kind as `A` returning the eigenvectors
+      !!                         of `A`. It is an `intent(out)` argument.
+      module subroutine diag_eigh(A, lambda, vectors)
+         !! Utility function to compute the eigenvalues and eigenvectors of a `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable, intent(out) :: lambda(:)
+         !! Eigenvalues.
+         real(dp), allocatable, optional, intent(out) :: vectors(:, :)
+         !! Eigenvectors.
+      end subroutine diag_eigh
    end interface
 
    !-------------------------------------

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -11,6 +11,7 @@ module SpecialMatrices_Tridiagonal
    public :: inv
    public :: matmul, spmv_ip
    public :: solve, solve_ip
+   public :: svd, svdvals
 
    ! --> Utility functions.
    public :: dense
@@ -829,6 +830,71 @@ module SpecialMatrices_Tridiagonal
          real(dp), allocatable :: B(:, :)
          !! Inverse of the matrix.
       end function diag_inv
+   end interface
+
+   interface svdvals
+      !! This interface overloads the `svdvals` interface from `stdlib_linalg` to compute the
+      !! singular values of a matrix \( A \) whose type is one of the types provided by
+      !! `SpecialMatrices`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    s = svdvals(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `s`   :  Vector of singular values sorted in decreasing order.
+      module function diag_svdvals(A) result(s)
+         !! Utility function to compute the singular values of a `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable :: s(:)
+         !! Singular values.
+      end function diag_svdvals
+   end interface
+
+   interface svd
+      !! This interface overloads the `svd` interface from `stdlib_linalg` to compute the
+      !! the singular value decomposition of a matrix \( A \) whose type is provided by
+      !! `SpecialMatrices`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    call svd(A, s, u, vt)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `s`   :  Rank-1 array `real` array returning the singular values of `A`.
+      !!          It is an `intent(out)` argument.
+      !!
+      !! `u` (optional) :  Rank-2 array of the same kind as `A` returning the left singular
+      !!                   vectors of `A` as columns. Its size should be `[n, n]`.
+      !!                   It is an `intent(out)` argument.
+      !!
+      !! `vt (optional) :  Rank-2 array of the same kind as `A` returning the right singular
+      !!                   vectors of `A` as rows. Its size should be `[n, n]`.
+      !!                   It is an `intent(out)` argument.
+      module subroutine diag_svd(A, u, s, vt)
+         !! Utility function to compute the singular value decomposition of a `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable, intent(out) :: s(:)
+         !! Singular values.
+         real(dp), allocatable, optional, intent(out) :: u(:, :)
+         !! Left singular vectors as columns.
+         real(dp), allocatable, optional, intent(out) :: vt(:, :)
+         !! Right singular vectors as rows.
+      end subroutine diag_svd
    end interface
 
    !-------------------------------------

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -9,7 +9,7 @@ module SpecialMatrices_Tridiagonal
    public :: det
    public :: trace
    public :: inv
-   public :: matmul
+   public :: matmul, spmv_ip
    public :: solve
 
    ! --> Utility functions.
@@ -528,6 +528,30 @@ module SpecialMatrices_Tridiagonal
       end function symtridiag_multi_spmv
    end interface
 
+   interface spmv_ip
+      module subroutine diag_spmv_ip(y, A, x)
+         !! Utility function to compute the matrix-vector product \( y = Ax \) where \( A \)
+         !! is of `Diagonal` type and `x` and `y` are both rank-1 arrays. Note that this
+         !! function performs this product in-place, i.e. `y` needs to be pre-allocated and
+         !! will be modified by the call.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(in) :: x(:)
+         !! Input vector.
+         real(dp), intent(out) :: y(:)
+         !! Output vector.
+      end subroutine diag_spmv_ip
+
+      module subroutine diag_multi_spmv_ip(Y, A, X)
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(in) :: X(:, :)
+         !! Input vectors.
+         real(dp), intent(out) :: Y(:, :)
+         !! Output vectors.
+      end subroutine diag_multi_spmv_ip
+   end interface
+
    !----------------------------------
    !-----     Linear Algebra     -----
    !----------------------------------
@@ -843,7 +867,7 @@ module SpecialMatrices_Tridiagonal
          !! Input matrix.
          integer(ilp), intent(in) :: dim
          !! Dimension whose size needs to be known.
-         integer(ilp) :: arr_size 
+         integer(ilp) :: arr_size
       end function diag_size
    end interface
 

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -6,9 +6,10 @@ module SpecialMatrices_Tridiagonal
 
    ! --> Linear Algebra.
    public :: transpose
+   public :: det
+   public :: trace
    public :: matmul
    public :: solve
-   ! public :: eig
 
    ! --> Utility functions.
    public :: dense
@@ -651,37 +652,54 @@ module SpecialMatrices_Tridiagonal
       end function symtridiag_multi_solve
    end interface
 
-   interface eig
-      !! This interface overloads the `eig` interface from `stdlib_linalg` for solving a
-      !! generalized eigenvalue problem \( A x = \lambda x \) where \( A \) is of one of the types
-      !! provided by `SpecialMatrices`. Whenever possible, eigensolvers specialized for the
-      !! particular matrix structure are being used. If not, \( A \) is converted to a standard
-      !! rank-2 array and the eigenpairs are computed using the `eig` from `stdlib_linalg`.
+   interface det
+      !! This interface overloads the `det` interface from `stdlib_linag` to compute the
+      !! determinant \(\det(A)\) where \(A\) is of one of the types provided by `SpecialMatrices`.
       !!
       !! #### Syntax
       !!
       !! ```fortran
-      !!    call eig(A, lambda, vectors)
+      !!    d = det(A)
       !! ```
       !!
       !! #### Arguments
       !!
-      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type. It
-      !!          is an `intent(in)` argument.
+      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type.
+      !!          It is in an `intent(in)` argument.
       !!
-      !! `lambda` :  `complex` rank-1 array containing the eigenvalues of \( A \). It is an
-      !!             `intent(out)` argument.
-      !!
-      !! `vectors`   :  `complex` rank-2 array containing th eigenvectors of \( A \). It is an
-      !!                `intent(out)` argument.
-      pure module subroutine diag_eig(A, lambda, vectors)
+      !! `determinant`  :  Determinant of the matrix.
+      pure module function diag_det(A) result(determinant)
+         !! Utility function to compute the determinant of a `Diagonal` matrix.
          type(Diagonal), intent(in) :: A
          !! Input matrix.
-         real(dp), intent(out) :: lambda(A%n)
-         !! Eigenvalues.
-         real(dp), intent(out) :: vectors(A%n, A%n)
-         !! Eigenvectors.
-      end subroutine diag_eig
+         real(dp) :: determinant
+         !! Determinant of the matrix.
+      end function diag_det
+   end interface
+
+   interface trace
+      !! This interface overloads the `trace` interface from `stdlib_linalg` to compute the trace
+      !! of a matrix \( A \) whose type one of the types provided by `SpecialMatrices`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    tr = trace(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `tr`  :  Trace of the matrix.
+      pure module function diag_trace(A) result(tr)
+         !! Utility function to compute the trace of a `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp) :: tr
+         !! Trace of the matrix.
+      end function diag_trace
    end interface
 
    !-------------------------------------

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -12,6 +12,7 @@ module SpecialMatrices_Tridiagonal
    public :: matmul, spmv_ip
    public :: solve, solve_ip
    public :: svd, svdvals
+   public :: eigvalsh
 
    ! --> Utility functions.
    public :: dense
@@ -849,7 +850,7 @@ module SpecialMatrices_Tridiagonal
       !!          It is an `intent(in)` argument.
       !!
       !! `s`   :  Vector of singular values sorted in decreasing order.
-      module function diag_svdvals(A) result(s)
+      pure module function diag_svdvals(A) result(s)
          !! Utility function to compute the singular values of a `Diagonal` matrix.
          type(Diagonal), intent(in) :: A
          !! Input matrix.
@@ -895,6 +896,31 @@ module SpecialMatrices_Tridiagonal
          real(dp), allocatable, optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
       end subroutine diag_svd
+   end interface
+
+   interface eigvalsh
+      !! This interface overloads the `eigvalsh` interface from `stdlib_linalg` to compute the
+      !! eigenvalues of a real-valued matrix \( A \) whose type is `Diagonal` or `SymTridiagonal`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    lambda = eigvalsh(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   :  `real-valued matrix of `Diagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `lambda` :  Vector of eigenvalues in increasing order.
+      module function diag_eigvalsh(A) result(lambda)
+         !! Utility function to compute the eigenvalues of a real `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable :: lambda(:)
+         !! Eigenvalues.
+      end function diag_eigvalsh
    end interface
 
    !-------------------------------------

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -15,6 +15,7 @@ module SpecialMatrices_Tridiagonal
    ! --> Utility functions.
    public :: dense
    public :: shape
+   public :: size
 
    !-----------------------------------------------------------
    !-----     Base types for bi/tri-diagonal matrices     -----
@@ -833,6 +834,17 @@ module SpecialMatrices_Tridiagonal
          type(SymTridiagonal) :: B
          !! Transpose of the original matrix.
       end function symtridiag_transpose
+   end interface
+
+   interface size
+      pure module function diag_size(A, dim) result(arr_size)
+         !! Utility function to return the size of a `Diagonal` matrix along a given dimension.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         integer(ilp), intent(in) :: dim
+         !! Dimension whose size needs to be known.
+         integer(ilp) :: arr_size 
+      end function diag_size
    end interface
 
    interface shape

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -8,6 +8,7 @@ module SpecialMatrices_Tridiagonal
    public :: transpose
    public :: det
    public :: trace
+   public :: inv
    public :: matmul
    public :: solve
 
@@ -679,7 +680,7 @@ module SpecialMatrices_Tridiagonal
 
    interface trace
       !! This interface overloads the `trace` interface from `stdlib_linalg` to compute the trace
-      !! of a matrix \( A \) whose type one of the types provided by `SpecialMatrices`.
+      !! of a matrix \( A \) whose type is one of the types provided by `SpecialMatrices`.
       !!
       !! #### Syntax
       !!
@@ -700,6 +701,32 @@ module SpecialMatrices_Tridiagonal
          real(dp) :: tr
          !! Trace of the matrix.
       end function diag_trace
+   end interface
+
+   interface inv
+      !! This interface overloads the `inv` interface from `stdlib_linalg` to compute the inverse
+      !! of a matrix \( A \) whose type is one of the types provided by `SpecialMatrices`. Note
+      !! that the inverse is returned as a standard Fortran rank-2 array.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    B = inv(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! `A`   :  Matrix of `Diagonal`, `Bidiagonal`, `Tridiagonal` or `SymTridiagonal` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! `B`   :  Inverse of the matrix \(A\). It is a standard Fortran rank-2 array.
+      pure module function diag_inv(A) result(B)
+         !! Utility function to compute the inverse of a `Diagonal` matrix.
+         type(Diagonal), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable :: B(:, :)
+         !! Inverse of the matrix.
+      end function diag_inv
    end interface
 
    !-------------------------------------

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -753,7 +753,7 @@ module SpecialMatrices_Tridiagonal
          !! Utility function to convert a `Diagonal` matrix to a regular rank-2 array.
          type(Diagonal), intent(in) :: A
          !! Input diagonal matrix.
-         real(dp) :: B(A%n, A%n)
+         real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
       end function diag_to_dense
 

--- a/src/specialmatrices_tridiagonal.f90
+++ b/src/specialmatrices_tridiagonal.f90
@@ -3,7 +3,7 @@ module SpecialMatrices_Tridiagonal
    use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling
    implicit none
    private
-   
+
    ! --> Linear Algebra.
    public :: transpose
    public :: matmul
@@ -157,10 +157,6 @@ module SpecialMatrices_Tridiagonal
       end function construct_dense_to_diag
    end interface
 
-
-
-
-
    interface Bidiagonal
       !! This interface provides different methods to construct a `Bidiagonal` matrix.
       !! Only `double precision` is supported currently. Only the non-zero elements of
@@ -242,9 +238,6 @@ module SpecialMatrices_Tridiagonal
          !! Corresponding bidiagonal matrix.
       end function construct_constant_bidiag
    end interface
-
-
-
 
    interface Tridiagonal
       !! This interface provides different methods to construct a `Tridiagonal` matrix.
@@ -340,10 +333,6 @@ module SpecialMatrices_Tridiagonal
       end function construct_dense_to_tridiag
    end interface
 
-
-
-
-
    interface SymTridiagonal
       !! This interface provides different methods to construct a `SymTridiagonal` matrix.
       !! Only `double precision` is supported currently. Only the non-zero elements of
@@ -434,7 +423,7 @@ module SpecialMatrices_Tridiagonal
       !!
       !! The intrinsic `matmul` is overloaded both for matrix-vector and matrix-matrix products.
       !! For a matrix-matrix product \( C = AB \), only the matrix \( A \) has to be of the ones
-      !! of the types defined by `SpecialMatrices`. Both \( B \) and \( C \) need to be standard 
+      !! of the types defined by `SpecialMatrices`. Both \( B \) and \( C \) need to be standard
       !! Fortran rank-2 arrays. All the underlying functions are defined as `pure`.
       !!
       !! #### Syntax
@@ -548,7 +537,7 @@ module SpecialMatrices_Tridiagonal
       !! #### Syntax
       !!
       !! To solve a system with \( A \) being of one of the types defined by `SpecialMatrices`:
-      !! 
+      !!
       !! ```fortran
       !!    y = solve(A, x)
       !! ```
@@ -586,7 +575,6 @@ module SpecialMatrices_Tridiagonal
          !! Solution vectors.
       end function diag_multi_solve
 
-
       ! Bidiagonal matrix solve.
       pure module function bidiag_solve(A, b) result(x)
          !! Utility function to solve a linear system \( Ax = b \) where \( A \) is of
@@ -612,7 +600,6 @@ module SpecialMatrices_Tridiagonal
          !! Solution vectors.
       end function bidiag_multi_solve
 
-      
       ! Tridiagonal matrix solve.
       pure module function tridiag_solve(A, b) result(x)
          !! Utility function to solve the linear system \( Ax = b \) where \( A \) is of
@@ -638,7 +625,6 @@ module SpecialMatrices_Tridiagonal
          !! Solution vectors.
       end function tridiag_multi_solve
 
-      
       ! Symmetric Tridiagonal matrix solve.
       pure module function symtridiag_solve(A, b) result(x)
          !! Utility function to solve the linear system \( Ax = b \) where \( A \) is of
@@ -664,9 +650,6 @@ module SpecialMatrices_Tridiagonal
          !! Solution vectors.
       end function symtridiag_multi_solve
    end interface
-
-
-
 
    interface eig
       !! This interface overloads the `eig` interface from `stdlib_linalg` for solving a
@@ -754,10 +737,6 @@ module SpecialMatrices_Tridiagonal
       end function symtridiag_to_dense
    end interface
 
-
-
-
-
    interface transpose
       !! This interface overloads the Fortran `intrinsic` procedure to define the transpose
       !! operation for the various types defined in `SpecialMatrices`.
@@ -810,10 +789,6 @@ module SpecialMatrices_Tridiagonal
          !! Transpose of the original matrix.
       end function symtridiag_transpose
    end interface
-
-
-
-
 
    interface shape
       !! This interface provides methods to access the shape of a matrix \( A \) of one of

--- a/src/specialmatrices_tridiagonal_generic.f90
+++ b/src/specialmatrices_tridiagonal_generic.f90
@@ -11,25 +11,25 @@ contains
 
    module procedure initialize_tridiag
       !! Utility procedure to construct a `Tridiagonal` matrix filled with zeros.
-      A%n = n; allocate (A%d(n), A%du(n - 1), A%dl(n - 1))
-      A%d = 0.0_dp; A%du = 0.0_dp; A%dl = 0.0_dp
-      return
+   A%n = n; allocate (A%d(n), A%du(n - 1), A%dl(n - 1))
+   A%d = 0.0_dp; A%du = 0.0_dp; A%dl = 0.0_dp
+   return
    end procedure initialize_tridiag
 
    module procedure construct_tridiag
       !! Utility procedure to construct a `Tridiagonal` matrix from rank-1 arrays.
-      A%n = size(d); A%dl = dl; A%d = d; A%du = du
+   A%n = size(d); A%dl = dl; A%d = d; A%du = du
    end procedure construct_tridiag
 
    module procedure construct_constant_tridiag
       !! Utility procedure to construct a `Tridiagonal` matrix with constant diagonals.
-      integer(ilp) :: i
-      A%n = n; A%dl = [(l, i=1, n - 1)]; A%d = [(d, i=1, n)]; A%du = [(u, i=1, n - 1)]
+   integer(ilp) :: i
+   A%n = n; A%dl = [(l, i=1, n - 1)]; A%d = [(d, i=1, n)]; A%du = [(u, i=1, n - 1)]
    end procedure construct_constant_tridiag
 
    module procedure construct_dense_to_tridiag
       !! Utility procedure to construct a `Tridiagonal` matrix from a rank-2 array.
-      B = Tridiagonal(diag(A, -1), diag(A), diag(A, 1))
+   B = Tridiagonal(diag(A, -1), diag(A), diag(A, 1))
    end procedure construct_dense_to_tridiag
 
    !------------------------------------------------------------
@@ -39,23 +39,23 @@ contains
    module procedure tridiag_spmv
       !! Utility procedure to compute the matrix-vector product \( y = Ax \) where \( A \)
       !! is of `Tridiagonal` type and `x` and `y` are both rank-1 arrays.
-      integer(ilp) :: i, n
-      n = size(x); allocate(y, mold=x)
-      y(1) = A%d(1)*x(1) + A%du(1)*x(2)
-      do concurrent(i=2:n - 1)
-         y(i) = A%dl(i-1)*x(i - 1) + A%d(i)*x(i) + A%du(i)*x(i + 1)
-      end do
-      y(n) = A%d(n)*x(n) + A%dl(n - 1)*x(n - 1)
+   integer(ilp) :: i, n
+   n = size(x); allocate (y, mold=x)
+   y(1) = A%d(1)*x(1) + A%du(1)*x(2)
+   do concurrent(i=2:n - 1)
+      y(i) = A%dl(i - 1)*x(i - 1) + A%d(i)*x(i) + A%du(i)*x(i + 1)
+   end do
+   y(n) = A%d(n)*x(n) + A%dl(n - 1)*x(n - 1)
    end procedure tridiag_spmv
 
    module procedure tridiag_multi_spmv
       !! Utility procedure to compute the matrix-matrix product \( Y = AX \) where \( A \)
       !!  is of `Tridiagonal` type and `X` and `Y` are both rank-2 arrays.
-      integer(ilp) :: i
-      allocate(Y, mold=X)
-      do concurrent(i=1:size(X, 2))
-         Y(:, i) = tridiag_spmv(A, X(:, i))
-      end do
+   integer(ilp) :: i
+   allocate (Y, mold=X)
+   do concurrent(i=1:size(X, 2))
+      Y(:, i) = tridiag_spmv(A, X(:, i))
+   end do
    end procedure tridiag_multi_spmv
 
    !----------------------------------
@@ -66,26 +66,26 @@ contains
       !! Utility procedure to solve the linear system \( Ax = b \) where \( A \) is of
       !! `Tridiagonal` type and `b` a rank-1 array. The solution `x` is also a rank-1 array
       !! with the same type and dimension as `b`.
-      integer(ilp) :: i, n, nrhs, info
-      real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
-      ! Initialize arrays.
-      n = A%n; dl = A%dl; d = A%d; du = A%du; b_(:, 1) = b ; nrhs = 1
-      ! Solve the system.
-      call gtsv(n, nrhs, dl, d, du, b_, n, info)
-      ! Return the solution.
-      x = b_(:, 1)
+   integer(ilp) :: i, n, nrhs, info
+   real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1), b_(A%n, 1)
+   ! Initialize arrays.
+   n = A%n; dl = A%dl; d = A%d; du = A%du; b_(:, 1) = b; nrhs = 1
+   ! Solve the system.
+   call gtsv(n, nrhs, dl, d, du, b_, n, info)
+   ! Return the solution.
+   x = b_(:, 1)
    end procedure tridiag_solve
 
    module procedure tridiag_multi_solve
       !! Utility procedure to solve a linear system with multiple right-hand sides where
       !! \( A \) is of `Tridiagonal` type and `B` a rank-2 array. The solution `X` is also
       !! a rank-2 array with the same type and dimensions as `B`.
-      integer(ilp) :: i, n, nrhs, info
-      real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
-      ! Initialize arrays.
-      n = A%n; dl = A%dl; d = A%d; du = A%du; nrhs = size(B, 2); X = B
-      ! Solve the systems.
-      call gtsv(n, nrhs, dl, d, du, X, n, info)
+   integer(ilp) :: i, n, nrhs, info
+   real(dp) :: dl(A%n - 1), d(A%n), du(A%n - 1)
+   ! Initialize arrays.
+   n = A%n; dl = A%dl; d = A%d; du = A%du; nrhs = size(B, 2); X = B
+   ! Solve the systems.
+   call gtsv(n, nrhs, dl, d, du, X, n, info)
    end procedure tridiag_multi_solve
 
    !-------------------------------------
@@ -93,26 +93,26 @@ contains
    !-------------------------------------
 
    module procedure tridiag_shape
-      shape = A%n
+   shape = A%n
    end procedure tridiag_shape
 
    module procedure tridiag_to_dense
       !! Utility procedure to convert a `Tridiagonal` matrix to a regular rank-2 array.
-      integer(ilp) :: i, n
-      n = A%n; B = 0.0_dp
-      B(1, 1) = A%d(1); B(1, 2) = A%du(1)
-      do concurrent(i=2:n - 1)
-         B(i, i - 1) = A%dl(i - 1)
-         B(i, i) = A%d(i)
-         B(i, i + 1) = A%du(i)
-      end do
-      B(n, n - 1) = A%dl(n - 1); B(n, n) = A%d(n)
+   integer(ilp) :: i, n
+   n = A%n; B = 0.0_dp
+   B(1, 1) = A%d(1); B(1, 2) = A%du(1)
+   do concurrent(i=2:n - 1)
+      B(i, i - 1) = A%dl(i - 1)
+      B(i, i) = A%d(i)
+      B(i, i + 1) = A%du(i)
+   end do
+   B(n, n - 1) = A%dl(n - 1); B(n, n) = A%d(n)
    end procedure tridiag_to_dense
 
    module procedure tridiag_transpose
       !! Utility procedure to compute the transpose of a `Tridiagonal` matrix.
       !! The output matrix is also of `Tridiagonal` type.
-      B = A; B%dl = A%du; B%du = A%dl
+   B = A; B%dl = A%du; B%du = A%dl
    end procedure tridiag_transpose
 
 end submodule GenericTridiagonal

--- a/test/Tester.f90
+++ b/test/Tester.f90
@@ -1,34 +1,34 @@
 program Tester
-    ! For best practice.
-    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
-    ! Unit-test utility.
-    use testdrive, only: run_testsuite, new_testsuite, testsuite_type
-    ! List of tests.
-    use TestTridiag
-    
-    implicit none
+   ! For best practice.
+   use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+   ! Unit-test utility.
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   ! List of tests.
+   use TestTridiag
 
-    ! Unit-test related.
-    integer :: status, is
-    type(testsuite_type), allocatable :: testsuites(:)
-    character(len=*), parameter :: fmt = '("#", *(1x, a))'
+   implicit none
 
-    status = 0
+   ! Unit-test related.
+   integer :: status, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
 
-    testsuites = [ new_testsuite("Tridiagonal Matrices", collect_diagonal_testsuite) ]
+   status = 0
 
-    do is = 1, size(testsuites)
-        write(output_unit, *)   "-----"
-        write(output_unit, fmt) "Testing :", testsuites(is)%name
-        write(output_unit, *)   "-----", new_line('a')
-        call run_testsuite(testsuites(is)%collect, error_unit, status)
-        write(output_unit, *) new_line('a')
-    enddo
+   testsuites = [new_testsuite("Tridiagonal Matrices", collect_diagonal_testsuite)]
 
-    if (status > 0) then
-        write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
-    else if (status == 0) then
-        write(output_unit, *) "All tests succesfully passed!", new_line('a')
-    endif
+   do is = 1, size(testsuites)
+      write (output_unit, *) "-----"
+      write (output_unit, fmt) "Testing :", testsuites(is)%name
+      write (output_unit, *) "-----", new_line('a')
+      call run_testsuite(testsuites(is)%collect, error_unit, status)
+      write (output_unit, *) new_line('a')
+   end do
+
+   if (status > 0) then
+      write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
+   else if (status == 0) then
+      write (output_unit, *) "All tests succesfully passed!", new_line('a')
+   end if
 
 end program

--- a/test/Tester.f90
+++ b/test/Tester.f90
@@ -15,7 +15,12 @@ program Tester
 
    status = 0
 
-   testsuites = [new_testsuite("Tridiagonal Matrices", collect_diagonal_testsuite)]
+   testsuites = [ &
+                new_testsuite("Diagonal Matrices", collect_diagonal_testsuite), &
+                new_testsuite("Bidiagonal Matrices", collect_bidiagonal_testsuite), &
+                new_testsuite("Tridiagonal Matrices", collect_tridiagonal_testsuite), &
+                new_testsuite("SymTriDiagonal Matrices", collect_symtridiagonal_testsuite) &
+                ]
 
    do is = 1, size(testsuites)
       write (output_unit, *) "-----"

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -89,7 +89,7 @@ contains
       ! Matrix-vector product.
       block
          real(dp), allocatable :: x(:), y(:), y_dense(:)
-         allocate (x(n), y(n), y_dense(n)); call random_number(x)
+         allocate (x(n)); call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
                     "Diagonal matrix-vector product failed.")
@@ -99,7 +99,7 @@ contains
       ! Matrix-matrix product.
       block
          real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-         allocate (x(n, n), y(n, n), y_dense(n, n))
+         allocate (x(n, n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -119,7 +119,7 @@ contains
       ! Solve with a single right-hand side vector.
       block
          real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-         allocate (x(n), x_stdlib(n), b(n))
+         allocate (b(n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -135,7 +135,7 @@ contains
       ! Solve with multiple right-hand side vectors.
       block
          real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         allocate (b(n, n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -176,7 +176,7 @@ contains
       ! Matrix-vector product with A lower bidiagonal.
       block
          real(dp), allocatable :: x(:), y(:), y_dense(:)
-         allocate (x(n), y(n), y_dense(n))
+         allocate (x(n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -193,7 +193,7 @@ contains
       ! Matrix-matrix product with A upper bidiagonal.
       block
          real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-         allocate (x(n, n), y(n, n), y_dense(n, n))
+         allocate (x(n, n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -221,7 +221,7 @@ contains
       ! Solve with a singe right-hand side vector.
       block
          real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-         allocate (x(n), x_stdlib(n), b(n))
+         allocate (b(n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -246,7 +246,7 @@ contains
 
       block
          real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         allocate (b(n, n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -298,7 +298,7 @@ contains
       ! Matrix-vector product.
       block
          real(dp), allocatable :: x(:), y(:), y_dense(:)
-         allocate (x(n), y(n), y_dense(n))
+         allocate (x(n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -309,7 +309,7 @@ contains
       ! Matrix-matrix product.
       block
          real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-         allocate (x(n, n), y(n, n), y_dense(n, n))
+         allocate (x(n, n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -331,7 +331,7 @@ contains
       ! Solve with a singe right-hand side vector.
       block
          real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-         allocate (x(n), x_stdlib(n), b(n))
+         allocate (b(n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -346,7 +346,7 @@ contains
 
       block
          real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         allocate (b(n, n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -387,7 +387,7 @@ contains
       ! Matrix-vector product.
       block
          real(dp), allocatable :: x(:), y(:), y_dense(:)
-         allocate (x(n), y(n), y_dense(n))
+         allocate (x(n))
          call random_number(x)
          y = matmul(A, x); y_dense = matmul(dense(A), x)
          call check(error, all_close(y, y_dense), &
@@ -420,7 +420,7 @@ contains
       ! Solve with a singe right-hand side vector.
       block
          real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-         allocate (x(n), x_stdlib(n), b(n))
+         allocate (b(n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
@@ -435,7 +435,7 @@ contains
 
       block
          real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         allocate (b(n, n))
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -36,7 +36,8 @@ contains
                   new_unittest("Diagonal in-place linear solver", test_diagonal_solve_ip), &
                   new_unittest("Diagonal svdvals", test_diagonal_svdvals), &
                   new_unittest("Diagonal svd", test_diagonal_svd), &
-                  new_unittest("Diagonal eigvalsh", test_diagonal_eigvalsh) &
+                  new_unittest("Diagonal eigvalsh", test_diagonal_eigvalsh), &
+                  new_unittest("Diagonal eigh", test_diagonal_eigh) &
                   ]
       return
    end subroutine collect_diagonal_testsuite
@@ -276,6 +277,24 @@ contains
                  "Diagonal eigvalsh failed.")
       return
    end subroutine test_diagonal_eigvalsh
+
+   subroutine test_diagonal_eigh(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:), Amat(:, :)
+      real(dp), allocatable :: lambda(:), vectors(:, :)
+
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+      ! Compute singular value decomposition.
+      call eigh(A, lambda, vectors)
+      ! Check error.
+      allocate (Amat(n, n)); Amat = 0.0_dp
+      Amat = matmul(vectors, matmul(diag(lambda), transpose(vectors)))
+      call check(error, all_close(dense(A), Amat), &
+                 "Diagonal eigh failed.")
+      return
+   end subroutine test_diagonal_eigh
 
    !---------------------------------------
    !-----     BIDIAGONAL MATRICES     -----

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -31,6 +31,7 @@ contains
                   new_unittest("Diagonal determinant", test_diagonal_det), &
                   new_unittest("Diagonal inverse", test_diagonal_inv), &
                   new_unittest("Diagonal matmul", test_diagonal_matmul), &
+                  new_unittest("Diagonal in-place matmul", test_diagonal_spmv_ip), &
                   new_unittest("Diagonal linear solver", test_diagonal_solve) &
                   ]
       return
@@ -107,6 +108,36 @@ contains
       end block
       return
    end subroutine test_diagonal_matmul
+
+   subroutine test_diagonal_spmv_ip(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+
+      ! Matrix-vector product.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n), y(n)); call random_number(x)
+         call spmv_ip(y, A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "in-place Diagonal matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
+
+      ! Matrix-matrix product.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n), y(n, n))
+         call random_number(x)
+         call spmv_ip(y, A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "in-place Diagonal matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_diagonal_spmv_ip
 
    subroutine test_diagonal_solve(error)
       type(error_type), allocatable, intent(out) :: error

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -2,7 +2,7 @@ module TestTridiag
    ! Fortran standard library.
    use stdlib_math, only: is_close, all_close
    use stdlib_linalg_constants, only: dp, ilp
-   use stdlib_linalg, only: solve
+   use stdlib_linalg, only: det, trace, solve
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
@@ -24,6 +24,8 @@ contains
       type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
       testsuite = [ &
+                  new_unittest("Diagonal trace", test_diagonal_trace), &
+                  new_unittest("Diagonal determinant", test_diagonal_det), &
                   new_unittest("Diagonal matmul", test_diagonal_matmul), &
                   new_unittest("Diagonal linear solver", test_diagonal_solve), &
                   new_unittest("Bidiagonal matmul", test_bidiagonal_matmul), &
@@ -35,6 +37,34 @@ contains
                   ]
       return
    end subroutine collect_diagonal_testsuite
+
+   subroutine test_diagonal_trace(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+
+      ! Compare against stdlib_linalg implementation.
+      call check(error, is_close(trace(A), trace(dense(A))), &
+                 "Diagonal trace failed.")
+      return
+   end subroutine test_diagonal_trace
+
+   subroutine test_diagonal_det(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+
+      ! Compare against stdlib_linalg implementation.
+      call check(error, is_close(det(A), det(dense(A))), &
+                 "Diagonal det failed.")
+      return
+   end subroutine test_diagonal_det
 
    subroutine test_diagonal_matmul(error)
       type(error_type), allocatable, intent(out) :: error

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -13,6 +13,9 @@ module TestTridiag
    integer, parameter :: n = 512
 
    public :: collect_diagonal_testsuite
+   public :: collect_bidiagonal_testsuite
+   public :: collect_tridiagonal_testsuite
+   public :: collect_symtridiagonal_testsuite
 
 contains
 
@@ -28,13 +31,7 @@ contains
                   new_unittest("Diagonal determinant", test_diagonal_det), &
                   new_unittest("Diagonal inverse", test_diagonal_inv), &
                   new_unittest("Diagonal matmul", test_diagonal_matmul), &
-                  new_unittest("Diagonal linear solver", test_diagonal_solve), &
-                  new_unittest("Bidiagonal matmul", test_bidiagonal_matmul), &
-                  new_unittest("Bidiagonal linear solver", test_bidiagonal_solve), &
-                  new_unittest("Tridiagonal matmul", test_tridiagonal_matmul), &
-                  new_unittest("Tridiagonal linear solver", test_tridiagonal_solve), &
-                  new_unittest("SymTridiagonal matmul", test_symtridiagonal_matmul), &
-                  new_unittest("SymTridiagonal linear solver", test_symtridiagonal_solve) &
+                  new_unittest("Diagonal linear solver", test_diagonal_solve) &
                   ]
       return
    end subroutine collect_diagonal_testsuite
@@ -156,6 +153,15 @@ contains
    !---------------------------------------
    !-----     BIDIAGONAL MATRICES     -----
    !---------------------------------------
+   subroutine collect_bidiagonal_testsuite(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("Bidiagonal matmul", test_bidiagonal_matmul), &
+                  new_unittest("Bidiagonal linear solver", test_bidiagonal_solve) &
+                  ]
+      return
+   end subroutine collect_bidiagonal_testsuite
 
    subroutine test_bidiagonal_matmul(error)
       type(error_type), allocatable, intent(out) :: error
@@ -269,6 +275,16 @@ contains
    !-----     TRIDIAGONAL MATRICES     -----
    !----------------------------------------
 
+   subroutine collect_tridiagonal_testsuite(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("Tridiagonal matmul", test_tridiagonal_matmul), &
+                  new_unittest("Tridiagonal linear solver", test_tridiagonal_solve) &
+                  ]
+      return
+   end subroutine collect_tridiagonal_testsuite
+
    subroutine test_tridiagonal_matmul(error)
       type(error_type), allocatable, intent(out) :: error
       type(Tridiagonal) :: A
@@ -348,6 +364,15 @@ contains
    !--------------------------------------------------
    !-----     SYMMETRIC TRIDIAGONAL MATRICES     -----
    !--------------------------------------------------
+   subroutine collect_symtridiagonal_testsuite(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("SymTridiagonal matmul", test_symtridiagonal_matmul), &
+                  new_unittest("SymTridiagonal linear solver", test_symtridiagonal_solve) &
+                  ]
+      return
+   end subroutine collect_symtridiagonal_testsuite
 
    subroutine test_symtridiagonal_matmul(error)
       type(error_type), allocatable, intent(out) :: error

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -2,7 +2,7 @@ module TestTridiag
    ! Fortran standard library.
    use stdlib_math, only: is_close, all_close
    use stdlib_linalg_constants, only: dp, ilp
-   use stdlib_linalg, only: det, trace, solve
+   use stdlib_linalg, only: det, trace, inv, solve
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
@@ -26,6 +26,7 @@ contains
       testsuite = [ &
                   new_unittest("Diagonal trace", test_diagonal_trace), &
                   new_unittest("Diagonal determinant", test_diagonal_det), &
+                  new_unittest("Diagonal inverse", test_diagonal_inv), &
                   new_unittest("Diagonal matmul", test_diagonal_matmul), &
                   new_unittest("Diagonal linear solver", test_diagonal_solve), &
                   new_unittest("Bidiagonal matmul", test_bidiagonal_matmul), &
@@ -65,6 +66,20 @@ contains
                  "Diagonal det failed.")
       return
    end subroutine test_diagonal_det
+
+   subroutine test_diagonal_inv(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+
+      ! Intialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+
+      ! Compare against stdlib_linalg implementation.
+      call check(error, all_close(inv(dense(A)), inv(A)), &
+                 "Diagonal inv failed.")
+      return
+   end subroutine test_diagonal_inv
 
    subroutine test_diagonal_matmul(error)
       type(error_type), allocatable, intent(out) :: error

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -1,383 +1,383 @@
 module TestTridiag
-    ! Fortran standard library.
-    use stdlib_math, only: is_close, all_close
-    use stdlib_linalg_constants, only: dp, ilp
-    use stdlib_linalg, only: solve
-    ! Testdrive.
-    use testdrive, only: new_unittest, unittest_type, error_type, check
-    ! SpecialMatrices
-    use SpecialMatrices
-    implicit none
-    private
+   ! Fortran standard library.
+   use stdlib_math, only: is_close, all_close
+   use stdlib_linalg_constants, only: dp, ilp
+   use stdlib_linalg, only: solve
+   ! Testdrive.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   ! SpecialMatrices
+   use SpecialMatrices
+   implicit none
+   private
 
-    integer, parameter :: n = 512
+   integer, parameter :: n = 512
 
-    public :: collect_diagonal_testsuite
+   public :: collect_diagonal_testsuite
 
 contains
 
-    !-------------------------------------
-    !-----     DIAGONAL MATRICES     -----
-    !-------------------------------------
+   !-------------------------------------
+   !-----     DIAGONAL MATRICES     -----
+   !-------------------------------------
 
-    subroutine collect_diagonal_testsuite(testsuite)
-        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+   subroutine collect_diagonal_testsuite(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
-        testsuite = [ &
-                    new_unittest("Diagonal matmul", test_diagonal_matmul),  &
-                    new_unittest("Diagonal linear solver", test_diagonal_solve),  &
-                    new_unittest("Bidiagonal matmul", test_bidiagonal_matmul),  &
-                    new_unittest("Bidiagonal linear solver", test_bidiagonal_solve),  &
-                    new_unittest("Tridiagonal matmul", test_tridiagonal_matmul),  &
-                    new_unittest("Tridiagonal linear solver", test_tridiagonal_solve),  &
-                    new_unittest("SymTridiagonal matmul", test_symtridiagonal_matmul),  &
-                    new_unittest("SymTridiagonal linear solver", test_symtridiagonal_solve)  &
-                    ]
-        return
-    end subroutine collect_diagonal_testsuite
+      testsuite = [ &
+                  new_unittest("Diagonal matmul", test_diagonal_matmul), &
+                  new_unittest("Diagonal linear solver", test_diagonal_solve), &
+                  new_unittest("Bidiagonal matmul", test_bidiagonal_matmul), &
+                  new_unittest("Bidiagonal linear solver", test_bidiagonal_solve), &
+                  new_unittest("Tridiagonal matmul", test_tridiagonal_matmul), &
+                  new_unittest("Tridiagonal linear solver", test_tridiagonal_solve), &
+                  new_unittest("SymTridiagonal matmul", test_symtridiagonal_matmul), &
+                  new_unittest("SymTridiagonal linear solver", test_symtridiagonal_solve) &
+                  ]
+      return
+   end subroutine collect_diagonal_testsuite
 
-    subroutine test_diagonal_matmul(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Diagonal) :: A
-        real(dp), allocatable :: dv(:)
+   subroutine test_diagonal_matmul(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
 
-        ! Initialize matrix.
-        allocate(dv(n)); call random_number(dv) ; A = Diagonal(dv)
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
 
-        ! Matrix-vector product.
-        block
-        real(dp), allocatable :: x(:), y(:), y_dense(:)
-        allocate(x(n), y(n), y_dense(n)); call random_number(x)
-        y = matmul(A, x) ; y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Diagonal matrix-vector product failed.")
-        if (allocated(error)) return
-        end block
+      ! Matrix-vector product.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n), y(n), y_dense(n)); call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Diagonal matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
 
-        ! Matrix-matrix product.
-        block
-        real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-        allocate(x(n, n), y(n, n), y_dense(n, n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Diagonal matrix-matrix product failed.")
-        end block
-        return
-    end subroutine test_diagonal_matmul
+      ! Matrix-matrix product.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n), y(n, n), y_dense(n, n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Diagonal matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_diagonal_matmul
 
-    subroutine test_diagonal_solve(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Diagonal) :: A
-        real(dp), allocatable :: dv(:)
-        
-        ! Initialize matrix.
-        allocate(dv(n)); call random_number(dv); A = Diagonal(dv)
+   subroutine test_diagonal_solve(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
 
-        ! Solve with a single right-hand side vector.
-        block
-        real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-        allocate(x(n), x_stdlib(n), b(n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Diagonal solve with a single rhs failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
 
-        ! Solve with multiple right-hand side vectors.
-        block
-        real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-        allocate(x(n, n), x_stdlib(n, n), b(n, n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Diagonal solve with multiple rhs failed.")
-        end block
+      ! Solve with a single right-hand side vector.
+      block
+         real(dp), allocatable :: x(:), x_stdlib(:), b(:)
+         allocate (x(n), x_stdlib(n), b(n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Diagonal solve with a single rhs failed.")
+         if (allocated(error)) return
+      end block
 
-        return
-    end subroutine test_diagonal_solve
+      ! Solve with multiple right-hand side vectors.
+      block
+         real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
+         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Diagonal solve with multiple rhs failed.")
+      end block
 
-    !---------------------------------------
-    !-----     BIDIAGONAL MATRICES     -----
-    !---------------------------------------
+      return
+   end subroutine test_diagonal_solve
 
-    subroutine test_bidiagonal_matmul(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Bidiagonal) :: A
-        real(dp), allocatable :: dv(:), ev(:)
+   !---------------------------------------
+   !-----     BIDIAGONAL MATRICES     -----
+   !---------------------------------------
 
-        ! Initialize matrix.
-        allocate(dv(n), ev(n-1))
-        call random_number(dv); call random_number(ev)
-        A = Bidiagonal(dv, ev, which="L")
+   subroutine test_bidiagonal_matmul(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Bidiagonal) :: A
+      real(dp), allocatable :: dv(:), ev(:)
 
-        ! Matrix-vector product with A lower bidiagonal.
-        block
-        real(dp), allocatable :: x(:), y(:), y_dense(:)
-        allocate(x(n), y(n), y_dense(n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Lower-bidiagonal matrix-vector product failed.")
-        if (allocated(error)) return
-        ! Matrix-vector product wih A upper bidiaognal.
-        A = Bidiagonal(dv, ev, which="U")
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Upper-bidiagonal matrix-vector product failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dv(n), ev(n - 1))
+      call random_number(dv); call random_number(ev)
+      A = Bidiagonal(dv, ev, which="L")
 
-        ! Matrix-matrix product with A upper bidiagonal.
-        block
-        real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-        allocate(x(n, n), y(n, n), y_dense(n, n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Upper-bidiagonal matrix-matrix product failed.")
-        if (allocated(error)) return
-        ! Matrix-matrix product with A lower bidiagonal.
-        A = Bidiagonal(dv, ev, which="L")
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Lower-bidiagonal matrix-matrix product failed.")
-        end block
-        return
-    end subroutine test_Bidiagonal_matmul
+      ! Matrix-vector product with A lower bidiagonal.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n), y(n), y_dense(n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Lower-bidiagonal matrix-vector product failed.")
+         if (allocated(error)) return
+         ! Matrix-vector product wih A upper bidiaognal.
+         A = Bidiagonal(dv, ev, which="U")
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Upper-bidiagonal matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
 
-    subroutine test_bidiagonal_solve(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Bidiagonal) :: A
-        real(dp), allocatable :: ev(:), dv(:)
+      ! Matrix-matrix product with A upper bidiagonal.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n), y(n, n), y_dense(n, n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Upper-bidiagonal matrix-matrix product failed.")
+         if (allocated(error)) return
+         ! Matrix-matrix product with A lower bidiagonal.
+         A = Bidiagonal(dv, ev, which="L")
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Lower-bidiagonal matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_Bidiagonal_matmul
 
-        ! Initialize matrix.
-        allocate(ev(n-1), dv(n))
-        call random_number(ev); call random_number(dv)
-        A = Bidiagonal(dv, ev, which="L")
+   subroutine test_bidiagonal_solve(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Bidiagonal) :: A
+      real(dp), allocatable :: ev(:), dv(:)
 
-        ! Solve with a singe right-hand side vector.
-        block
-        real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-        allocate(x(n), x_stdlib(n), b(n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Lower-bidiagonal solve with a single rhs failed.")
-        if (allocated(error)) return
+      ! Initialize matrix.
+      allocate (ev(n - 1), dv(n))
+      call random_number(ev); call random_number(dv)
+      A = Bidiagonal(dv, ev, which="L")
 
-        A = Bidiagonal(dv, ev, which="U")
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Upper-bidiagonal solve with a single rhs failed.")
-        if (allocated(error)) return
-        end block
+      ! Solve with a singe right-hand side vector.
+      block
+         real(dp), allocatable :: x(:), x_stdlib(:), b(:)
+         allocate (x(n), x_stdlib(n), b(n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Lower-bidiagonal solve with a single rhs failed.")
+         if (allocated(error)) return
 
-        block
-        real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-        allocate(x(n, n), x_stdlib(n, n), b(n, n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Upper-bidiagonal solve with multiple rhs failed.")
-        if(allocated(error)) return
+         A = Bidiagonal(dv, ev, which="U")
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Upper-bidiagonal solve with a single rhs failed.")
+         if (allocated(error)) return
+      end block
 
-        A = Bidiagonal(dv, ev, which="L")
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Lower-bidiagonal solve with multiple rhs failed.")
-        end block
+      block
+         real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
+         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Upper-bidiagonal solve with multiple rhs failed.")
+         if (allocated(error)) return
 
-        return
-    end subroutine test_bidiagonal_solve
+         A = Bidiagonal(dv, ev, which="L")
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Lower-bidiagonal solve with multiple rhs failed.")
+      end block
 
-    !----------------------------------------
-    !-----     TRIDIAGONAL MATRICES     -----
-    !----------------------------------------
+      return
+   end subroutine test_bidiagonal_solve
 
-    subroutine test_tridiagonal_matmul(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Tridiagonal) :: A
-        real(dp), allocatable :: dl(:), dv(:), du(:)
+   !----------------------------------------
+   !-----     TRIDIAGONAL MATRICES     -----
+   !----------------------------------------
 
-        ! Initialize matrix.
-        allocate(dl(n-1), dv(n), du(n-1))
-        call random_number(dl); call random_number(dv); call random_number(du)
-        A = Tridiagonal(dl, dv, du)
+   subroutine test_tridiagonal_matmul(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Tridiagonal) :: A
+      real(dp), allocatable :: dl(:), dv(:), du(:)
 
-        ! Matrix-vector product.
-        block
-        real(dp), allocatable :: x(:), y(:), y_dense(:)
-        allocate(x(n), y(n), y_dense(n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Tridiagonal matrix-vector product failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dl(n - 1), dv(n), du(n - 1))
+      call random_number(dl); call random_number(dv); call random_number(du)
+      A = Tridiagonal(dl, dv, du)
 
-        ! Matrix-matrix product.
-        block
-        real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-        allocate(x(n, n), y(n, n), y_dense(n, n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "Tridiagonal matrix-matrix product failed.")
-        end block
-        return
-    end subroutine test_tridiagonal_matmul
+      ! Matrix-vector product.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n), y(n), y_dense(n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Tridiagonal matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
 
-    subroutine test_tridiagonal_solve(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(Tridiagonal) :: A
-        real(dp), allocatable :: dl(:), dv(:), du(:)
+      ! Matrix-matrix product.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n), y(n, n), y_dense(n, n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Tridiagonal matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_tridiagonal_matmul
 
-        ! Initialize matrix.
-        allocate(dl(n-1), dv(n), du(n-1))
-        call random_number(dl); call random_number(dv); call random_number(du)
-        A = Tridiagonal(dl, dv, du)
+   subroutine test_tridiagonal_solve(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Tridiagonal) :: A
+      real(dp), allocatable :: dl(:), dv(:), du(:)
 
-        ! Solve with a singe right-hand side vector.
-        block
-        real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-        allocate(x(n), x_stdlib(n), b(n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Tridiagonal solve with a single rhs failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dl(n - 1), dv(n), du(n - 1))
+      call random_number(dl); call random_number(dv); call random_number(du)
+      A = Tridiagonal(dl, dv, du)
 
-        block
-        real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-        allocate(x(n, n), x_stdlib(n, n), b(n, n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "Tridiagonal solve with multiple rhs failed.")
-        end block
+      ! Solve with a singe right-hand side vector.
+      block
+         real(dp), allocatable :: x(:), x_stdlib(:), b(:)
+         allocate (x(n), x_stdlib(n), b(n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Tridiagonal solve with a single rhs failed.")
+         if (allocated(error)) return
+      end block
 
-        return
-    end subroutine test_tridiagonal_solve
+      block
+         real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
+         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "Tridiagonal solve with multiple rhs failed.")
+      end block
 
-    !--------------------------------------------------
-    !-----     SYMMETRIC TRIDIAGONAL MATRICES     -----
-    !--------------------------------------------------
+      return
+   end subroutine test_tridiagonal_solve
 
-    subroutine test_symtridiagonal_matmul(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(SymTridiagonal) :: A
-        real(dp), allocatable :: dv(:), ev(:)
+   !--------------------------------------------------
+   !-----     SYMMETRIC TRIDIAGONAL MATRICES     -----
+   !--------------------------------------------------
 
-        ! Initialize matrix.
-        allocate(dv(n), ev(n-1))
-        call random_number(dv); call random_number(ev)
-        A = SymTridiagonal(dv, ev)
+   subroutine test_symtridiagonal_matmul(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(SymTridiagonal) :: A
+      real(dp), allocatable :: dv(:), ev(:)
 
-        ! Matrix-vector product.
-        block
-        real(dp), allocatable :: x(:), y(:), y_dense(:)
-        allocate(x(n), y(n), y_dense(n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "SymTridiagonal matrix-vector product failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dv(n), ev(n - 1))
+      call random_number(dv); call random_number(ev)
+      A = SymTridiagonal(dv, ev)
 
-        ! Matrix-matrix product.
-        block
-        real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
-        allocate(x(n, n), y(n, n), y_dense(n, n))
-        call random_number(x)
-        y = matmul(A, x); y_dense = matmul(dense(A), x)
-        call check(error, all_close(y, y_dense), &
-        "SymTridiagonal matrix-matrix product failed.")
-        end block
-        return
-    end subroutine test_symtridiagonal_matmul
+      ! Matrix-vector product.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n), y(n), y_dense(n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "SymTridiagonal matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
 
-    subroutine test_symtridiagonal_solve(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(SymTridiagonal) :: A
-        real(dp), allocatable :: dv(:), ev(:)
+      ! Matrix-matrix product.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n), y(n, n), y_dense(n, n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "SymTridiagonal matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_symtridiagonal_matmul
 
-        ! Initialize matrix.
-        allocate(dv(n), ev(n-1))
-        call random_number(dv); call random_number(ev)
-        A = SymTridiagonal(dv, ev)
+   subroutine test_symtridiagonal_solve(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(SymTridiagonal) :: A
+      real(dp), allocatable :: dv(:), ev(:)
 
-        ! Solve with a singe right-hand side vector.
-        block
-        real(dp), allocatable :: x(:), x_stdlib(:), b(:)
-        allocate(x(n), x_stdlib(n), b(n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "SymTridiagonal solve with a single rhs failed.")
-        if (allocated(error)) return
-        end block
+      ! Initialize matrix.
+      allocate (dv(n), ev(n - 1))
+      call random_number(dv); call random_number(ev)
+      A = SymTridiagonal(dv, ev)
 
-        block
-        real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
-        allocate(x(n, n), x_stdlib(n, n), b(n, n))
-        ! Random rhs.
-        call random_number(b)
-        ! Solve with SpecialMatrices.
-        x = solve(A, b)
-        ! Solve with stdlib (dense).
-        x_stdlib = solve(dense(A), b)
-        ! Check error.
-        call check(error, all_close(x, x_stdlib), &
-        "SymTridiagonal solve with multiple rhs failed.")
-        end block
+      ! Solve with a singe right-hand side vector.
+      block
+         real(dp), allocatable :: x(:), x_stdlib(:), b(:)
+         allocate (x(n), x_stdlib(n), b(n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "SymTridiagonal solve with a single rhs failed.")
+         if (allocated(error)) return
+      end block
 
-        return
-    end subroutine test_symtridiagonal_solve
+      block
+         real(dp), allocatable :: x(:, :), x_stdlib(:, :), b(:, :)
+         allocate (x(n, n), x_stdlib(n, n), b(n, n))
+         ! Random rhs.
+         call random_number(b)
+         ! Solve with SpecialMatrices.
+         x = solve(A, b)
+         ! Solve with stdlib (dense).
+         x_stdlib = solve(dense(A), b)
+         ! Check error.
+         call check(error, all_close(x, x_stdlib), &
+                    "SymTridiagonal solve with multiple rhs failed.")
+      end block
+
+      return
+   end subroutine test_symtridiagonal_solve
 
 end module

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -10,7 +10,7 @@ module TestTridiag
    implicit none
    private
 
-   integer, parameter :: n = 5
+   integer, parameter :: n = 512
 
    public :: collect_diagonal_testsuite
    public :: collect_bidiagonal_testsuite

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -2,7 +2,7 @@ module TestTridiag
    ! Fortran standard library.
    use stdlib_math, only: is_close, all_close
    use stdlib_linalg_constants, only: dp, ilp
-   use stdlib_linalg, only: diag, det, trace, inv, solve, svdvals
+   use stdlib_linalg, only: diag, det, trace, inv, solve, svdvals, eigvalsh
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
@@ -10,7 +10,7 @@ module TestTridiag
    implicit none
    private
 
-   integer, parameter :: n = 512
+   integer, parameter :: n = 5
 
    public :: collect_diagonal_testsuite
    public :: collect_bidiagonal_testsuite
@@ -35,7 +35,8 @@ contains
                   new_unittest("Diagonal linear solver", test_diagonal_solve), &
                   new_unittest("Diagonal in-place linear solver", test_diagonal_solve_ip), &
                   new_unittest("Diagonal svdvals", test_diagonal_svdvals), &
-                  new_unittest("Diagonal svd", test_diagonal_svd) &
+                  new_unittest("Diagonal svd", test_diagonal_svd), &
+                  new_unittest("Diagonal eigvalsh", test_diagonal_eigvalsh) &
                   ]
       return
    end subroutine collect_diagonal_testsuite
@@ -259,6 +260,22 @@ contains
                  "Diagonal svd failed.")
       return
    end subroutine test_diagonal_svd
+
+   subroutine test_diagonal_eigvalsh(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+      real(dp), allocatable :: lambda(:), lambda_stdlib(:)
+
+      ! Initialize array.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+      ! Compute singular values.
+      lambda = eigvalsh(A); lambda_stdlib = eigvalsh(dense(A))
+      ! Check error.
+      call check(error, all_close(lambda, lambda_stdlib), &
+                 "Diagonal eigvalsh failed.")
+      return
+   end subroutine test_diagonal_eigvalsh
 
    !---------------------------------------
    !-----     BIDIAGONAL MATRICES     -----

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -2,7 +2,7 @@ module TestTridiag
    ! Fortran standard library.
    use stdlib_math, only: is_close, all_close
    use stdlib_linalg_constants, only: dp, ilp
-   use stdlib_linalg, only: det, trace, inv, solve
+   use stdlib_linalg, only: diag, det, trace, inv, solve, svdvals
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
@@ -33,7 +33,9 @@ contains
                   new_unittest("Diagonal matmul", test_diagonal_matmul), &
                   new_unittest("Diagonal in-place matmul", test_diagonal_spmv_ip), &
                   new_unittest("Diagonal linear solver", test_diagonal_solve), &
-                  new_unittest("Diagonal in-place linear solver", test_diagonal_solve_ip) &
+                  new_unittest("Diagonal in-place linear solver", test_diagonal_solve_ip), &
+                  new_unittest("Diagonal svdvals", test_diagonal_svdvals), &
+                  new_unittest("Diagonal svd", test_diagonal_svd) &
                   ]
       return
    end subroutine collect_diagonal_testsuite
@@ -223,6 +225,40 @@ contains
 
       return
    end subroutine test_diagonal_solve_ip
+
+   subroutine test_diagonal_svdvals(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:)
+      real(dp), allocatable :: s(:), s_stdlib(:)
+
+      ! Initialize array.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+      ! Compute singular values.
+      s = svdvals(A); s_stdlib = svdvals(dense(A))
+      ! Check error.
+      call check(error, all_close(s, s_stdlib), &
+                 "Diagonal svdvals failed.")
+      return
+   end subroutine test_diagonal_svdvals
+
+   subroutine test_diagonal_svd(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(Diagonal) :: A
+      real(dp), allocatable :: dv(:), Amat(:, :)
+      real(dp), allocatable :: u(:, :), s(:), vt(:, :)
+
+      ! Initialize matrix.
+      allocate (dv(n)); call random_number(dv); A = Diagonal(dv)
+      ! Compute singular value decomposition.
+      call svd(A, u, s, vt)
+      ! Check error.
+      allocate (Amat(n, n)); Amat = 0.0_dp
+      Amat = matmul(u, matmul(diag(s), vt))
+      call check(error, all_close(dense(A), Amat), &
+                 "Diagonal svd failed.")
+      return
+   end subroutine test_diagonal_svd
 
    !---------------------------------------
    !-----     BIDIAGONAL MATRICES     -----


### PR DESCRIPTION
- fprettify'ied the source code.
- fprettify'ied the tests.
- Added support for det and trace for Diagonal matrices.
- Added support for inverse of Diagonal matrices.
- Slight refactoring of the tests.
- Made  use allocatable output matrix.
- Exported  for  matrices.
- Cleaned-up tests a bit.
- Added in-place matrix-vector product for Diagonal matrices.
- Added in-place linear solver for Diagonal matrices.
- Added svd and svdvals for Diagonal matrices.
- Added support for eigvalsh for real Diagonal matrices.
- Added eigh support for Diagonal matrices.
- Reset n = 512 in the definition of the tests.
