### PR TITLE
lapackify

### DIFF
--- a/src/Bidiagonal/matvecs.f90
+++ b/src/Bidiagonal/matvecs.f90
@@ -8,21 +8,19 @@ contains
    character :: trans
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
-   real(dp), target, allocatable :: dummy(:)
-   real(dp), pointer :: dl(:), dv(:), du(:)
+   real(dp), allocatable :: dummy(:)
    real(dp), pointer :: xmat(:, :), ymat(:, :)
 
    ! Setup variables.
    n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"; allocate (dummy(n-1)); dummy = 0.0_dp
-   select case(A%which)
-   case("L")
-      dl(1:n-1) => A%ev; dv(1:n) => A%dv; du(1:n-1) => dummy
-   case("U")
-      dl(1:n-1) => dummy; dv(1:n) => A%dv; du(1:n-1) => A%ev
-   end select
    y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
    ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
+   select case(A%which)
+   case("L")
+      call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, xmat, ldx, beta, ymat, ldy)
+   case("U")
+      call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
+   end select
 
    end procedure
 
@@ -32,19 +30,17 @@ contains
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
    real(dp), target, allocatable :: dummy(:)
-   real(dp), pointer :: dl(:), dv(:), du(:)
 
    ! Setup variables.
    n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
    allocate (dummy(n-1)); dummy = 0.0_dp; y = x
+   ! Matrix-vector product.
    select case(A%which)
    case("L")
-      dl(1:n-1) => A%ev; dv(1:n) => A%dv; du(1:n-1) => dummy
+      call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, x, ldx, beta, y, ldy)
    case("U")
-      dl(1:n-1) => dummy; dv(1:n) => A%dv; du(1:n-1) => A%ev
+      call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, x, ldx, beta, y, ldy)
    end select
-   ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
 
    end procedure
 end submodule

--- a/src/Bidiagonal/matvecs.f90
+++ b/src/Bidiagonal/matvecs.f90
@@ -12,13 +12,13 @@ contains
    real(dp), pointer :: xmat(:, :), ymat(:, :)
 
    ! Setup variables.
-   n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"; allocate (dummy(n-1)); dummy = 0.0_dp
+   n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"; allocate (dummy(n - 1)); dummy = 0.0_dp
    y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
    ! Matrix-vector product.
-   select case(A%which)
-   case("L")
+   select case (A%which)
+   case ("L")
       call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, xmat, ldx, beta, ymat, ldy)
-   case("U")
+   case ("U")
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
    end select
 
@@ -33,12 +33,12 @@ contains
 
    ! Setup variables.
    n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
-   allocate (dummy(n-1)); dummy = 0.0_dp; y = x
+   allocate (dummy(n - 1)); dummy = 0.0_dp; y = x
    ! Matrix-vector product.
-   select case(A%which)
-   case("L")
+   select case (A%which)
+   case ("L")
       call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, x, ldx, beta, y, ldy)
-   case("U")
+   case ("U")
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, x, ldx, beta, y, ldy)
    end select
 

--- a/src/Bidiagonal/matvecs.f90
+++ b/src/Bidiagonal/matvecs.f90
@@ -1,28 +1,50 @@
 submodule(specialmatrices_bidiagonal) bidiagonal_matvecs
+   use stdlib_linalg_lapack, only: lagtm
    implicit none(type, external)
 contains
+
    module procedure spmv
-   integer(ilp) :: i, n
-   n = A%n; allocate (y, mold=x)
-   select case (A%which)
-   case ("L")
-      y(1) = A%dv(1)*x(1)
-      do concurrent(i=2:n)
-         y(i) = A%ev(i - 1)*x(i - 1) + A%dv(i)*x(i)
-      end do
-   case ("U")
-      do concurrent(i=1:n - 1)
-         y(i) = A%dv(i)*x(i) + A%ev(i)*x(i + 1)
-      end do
-      y(n) = A%dv(n)*x(n)
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), target, allocatable :: dummy(:)
+   real(dp), pointer :: dl(:), dv(:), du(:)
+   real(dp), pointer :: xmat(:, :), ymat(:, :)
+
+   ! Setup variables.
+   n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"; allocate (dummy(n-1)); dummy = 0.0_dp
+   select case(A%which)
+   case("L")
+      dl(1:n-1) => A%ev; dv(1:n) => A%dv; du(1:n-1) => dummy
+   case("U")
+      dl(1:n-1) => dummy; dv(1:n) => A%dv; du(1:n-1) => A%ev
    end select
+   y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
+
    end procedure
 
    module procedure spmvs
-   integer(ilp) :: i, j, n, nvecs
-   n = A%n; nvecs = size(x, 2); allocate (y, mold=x)
-   do concurrent(i=1:nvecs)
-      y(:, i) = spmv(A, x(:, i))
-   end do
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), target, allocatable :: dummy(:)
+   real(dp), pointer :: dl(:), dv(:), du(:)
+
+   ! Setup variables.
+   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
+   allocate (dummy(n-1)); dummy = 0.0_dp; y = x
+   select case(A%which)
+   case("L")
+      dl(1:n-1) => A%ev; dv(1:n) => A%dv; du(1:n-1) => dummy
+   case("U")
+      dl(1:n-1) => dummy; dv(1:n) => A%dv; du(1:n-1) => A%ev
+   end select
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
+
    end procedure
 end submodule

--- a/src/Bidiagonal/solve.f90
+++ b/src/Bidiagonal/solve.f90
@@ -23,10 +23,8 @@ contains
    module procedure solve_multi_rhs
    integer(ilp) :: i, n, nrhs, info
    real(dp), allocatable :: dl(:), dv(:), du(:)
-   real(dp), pointer :: xmat(:, :)
    ! Initialize arrays.
-   n = A%n; nrhs = size(b, 2)
-   x = b; xmat(1:n, 1:nrhs) => x
+   n = A%n; nrhs = size(b, 2); x = b
    ! Dispatch to solver.
    select case (A%which)
    case ("L")
@@ -35,6 +33,6 @@ contains
       dv = A%dv; dl = 0.0_dp*A%ev; du = A%ev
    end select
    ! Solve.
-   call gtsv(n, nrhs, dl, dv, du, xmat, n, info)
+   call gtsv(n, nrhs, dl, dv, du, x, n, info)
    end procedure
 end submodule

--- a/src/Bidiagonal/specialmatrices_bidiagonal.f90
+++ b/src/Bidiagonal/specialmatrices_bidiagonal.f90
@@ -140,22 +140,22 @@ module specialmatrices_bidiagonal
       !! ```fortran
       !!    C = matmul(A, B)
       !! ```
-      pure module function spmv(A, x) result(y)
+      module function spmv(A, x) result(y)
          !! Compute the matrix-vector product \(y = Ax\) for a `Bidiagonal` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
-         type(Bidiagonal), intent(in) :: A
+         type(Bidiagonal), target, intent(in) :: A
          !! Input matrix.
-         real(dp), intent(in) :: x(:)
+         real(dp), target, intent(in) :: x(:)
          !! Input vector.
-         real(dp), allocatable :: y(:)
+         real(dp), target, allocatable :: y(:)
          !! Output vector.
       end function
 
-      pure module function spmvs(A, x) result(y)
+      module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Bidiagonal` matrix \(A\) and a
          !! dense matrix \(X\) (rank-2 array). \(Y\) is also a rank-2 array with the same
          !! dimensions as \(X\).
-         type(Bidiagonal), intent(in) :: A
+         type(Bidiagonal), target, intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
          !! Input vectors.

--- a/src/Bidiagonal/specialmatrices_bidiagonal.f90
+++ b/src/Bidiagonal/specialmatrices_bidiagonal.f90
@@ -151,11 +151,11 @@ module specialmatrices_bidiagonal
          !! Output vector.
       end function
 
-      module function spmvs(A, x) result(y)
+      pure module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Bidiagonal` matrix \(A\) and a
          !! dense matrix \(X\) (rank-2 array). \(Y\) is also a rank-2 array with the same
          !! dimensions as \(X\).
-         type(Bidiagonal), target, intent(in) :: A
+         type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
          !! Input vectors.

--- a/src/SymTridiagonal/matvecs.f90
+++ b/src/SymTridiagonal/matvecs.f90
@@ -1,23 +1,36 @@
 submodule(specialmatrices_symtridiagonal) symtridiagonal_matvecs
+   use stdlib_linalg_lapack, only: lagtm
    implicit none(type, external)
 contains
    module procedure spmv
-   integer(ilp) :: i, n
-   n = A%n; allocate (y, mold=x)
-   y(1) = A%dv(1)*x(1) + A%ev(1)*x(2)
-   do concurrent(i=2:n - 1)
-      y(i) = A%ev(i - 1)*x(i - 1) + A%dv(i)*x(i) + A%ev(i)*x(i + 1)
-   end do
-   y(n) = A%dv(n)*x(n) + A%ev(n - 1)*x(n - 1)
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), allocatable :: dl(:), dv(:), du(:)
+   real(dp), pointer :: xmat(:, :), ymat(:, :)
+
+   ! Setup variables.
+   n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"
+   dl = A%ev; dv = A%dv; du = A%ev
+   y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
+   
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
    end procedure
 
    module procedure spmvs
-   integer(ilp) :: i, j, n, nvecs
-   n = A%n; nvecs = size(x, 2); allocate (y, mold=x)
-   y(1, :) = A%dv(1)*x(1, :) + A%ev(1)*x(2, :)
-   do concurrent(i=2:n - 1, j=1:nvecs)
-      y(i, j) = A%ev(i - 1)*x(i - 1, j) + A%dv(i)*x(i, j) + A%ev(i)*x(i + 1, j)
-   end do
-   y(n, :) = A%dv(n)*x(n, :) + A%ev(n - 1)*x(n - 1, :)
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), allocatable :: dl(:), dv(:), du(:)
+
+   ! Setup variables.
+   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
+   dl = A%ev; dv = A%dv; du = A%ev; y = x
+
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
    end procedure
 end submodule

--- a/src/SymTridiagonal/matvecs.f90
+++ b/src/SymTridiagonal/matvecs.f90
@@ -7,16 +7,14 @@ contains
    character :: trans
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
-   real(dp), allocatable :: dl(:), dv(:), du(:)
    real(dp), pointer :: xmat(:, :), ymat(:, :)
 
    ! Setup variables.
    n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"
-   dl = A%ev; dv = A%dv; du = A%ev
    y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
-   
    ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
+   call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
+
    end procedure
 
    module procedure spmvs
@@ -24,13 +22,11 @@ contains
    character :: trans
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
-   real(dp), allocatable :: dl(:), dv(:), du(:)
 
    ! Setup variables.
-   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
-   dl = A%ev; dv = A%dv; du = A%ev; y = x
-
+   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"; y = x
    ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
+   call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, A%ev, x, ldx, beta, y, ldy)
+
    end procedure
 end submodule

--- a/src/SymTridiagonal/solve.f90
+++ b/src/SymTridiagonal/solve.f90
@@ -19,14 +19,12 @@ contains
    module procedure solve_multi_rhs
    integer(ilp) :: i, n, nrhs, info
    real(dp), allocatable :: dl(:), d(:), du(:)
-   real(dp), pointer :: xmat(:, :)
    ! Initialize arrays.
-   n = A%n; nrhs = size(b, 2); dl = A%ev; d = A%dv; du = A%ev
-   x = b; xmat(1:n, 1:nrhs) => x
+   n = A%n; nrhs = size(b, 2); dl = A%ev; d = A%dv; du = A%ev; x = b
    if (A%isposdef) then
-      call ptsv(n, nrhs, d, du, xmat, n, info)
+      call ptsv(n, nrhs, d, du, x, n, info)
    else
-      call gtsv(n, nrhs, dl, d, du, xmat, n, info)
+      call gtsv(n, nrhs, dl, d, du, x, n, info)
    end if
    end procedure
 end submodule

--- a/src/SymTridiagonal/solve.f90
+++ b/src/SymTridiagonal/solve.f90
@@ -1,30 +1,250 @@
 submodule(specialmatrices_symtridiagonal) symtridiagonal_linear_solver
-   use stdlib_linalg_lapack, only: gtsv, ptsv
+   use stdlib_optval, only: optval
+   use stdlib_linalg_lapack, only: gttrf, gttrs, gtrfs
+   use stdlib_linalg_lapack, only: pttrf, pttrs, ptrfs
+   use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling, LINALG_ERROR, &
+                                  LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR, LINALG_SUCCESS
    implicit none(type, external)
+
+   character(*), parameter :: this = "symtridiagonal_linear_solver"
 contains
+
    module procedure solve_single_rhs
-   integer(ilp) :: i, n, nrhs, info
-   real(dp), allocatable :: dl(:), d(:), du(:)
-   real(dp), pointer :: xmat(:, :)
-   ! Initialize arrays.
-   n = A%n; nrhs = 1; dl = A%ev; d = A%dv; du = A%ev
-   x = b; xmat(1:n, 1:nrhs) => x
+   ! Local variables.
+   logical(lk) :: refine_
+   real(dp), pointer :: xmat(:, :), bmat(:, :)
+   refine_ = optval(refine, .false.)
+   x = b; xmat(1:A%n, 1:1) => x; bmat(1:A%n, 1:1) => b
    if (A%isposdef) then
-      call ptsv(n, nrhs, d, du, xmat, n, info)
+      xmat = posdef_symtridiagonal_solver(A, bmat, refine_)
    else
-      call gtsv(n, nrhs, dl, d, du, xmat, n, info)
+      xmat = symtridiagonal_solver(A, bmat, refine_)
    end if
    end procedure
 
    module procedure solve_multi_rhs
-   integer(ilp) :: i, n, nrhs, info
-   real(dp), allocatable :: dl(:), d(:), du(:)
-   ! Initialize arrays.
-   n = A%n; nrhs = size(b, 2); dl = A%ev; d = A%dv; du = A%ev; x = b
+   ! Local variables.
+   logical(lk) :: refine_
+   refine_ = optval(refine, .false.)
    if (A%isposdef) then
-      call ptsv(n, nrhs, d, du, x, n, info)
+      x = posdef_symtridiagonal_solver(A, b, refine_)
    else
-      call gtsv(n, nrhs, dl, d, du, x, n, info)
+      x = symtridiagonal_solver(A, b, refine_)
    end if
    end procedure
+
+   !---------------------------------------------------
+   !-----     Generic (Sym)Tridiagonal Solver     -----
+   !---------------------------------------------------
+
+   ! Process GTTRF
+   elemental subroutine handle_gttrf_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRF return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gttrf")
+      end select
+   end subroutine handle_gttrf_info
+
+   ! Process GTTRS
+   elemental subroutine handle_gttrs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gttrs")
+      end select
+   end subroutine handle_gttrs_info
+
+   ! Process GTRFS
+   elemental subroutine handle_gtrfs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTRFS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gtrfs")
+      end select
+   end subroutine handle_gtrfs_info
+
+   function symtridiagonal_solver(A, b, refine) result(x)
+      type(SymTridiagonal), intent(in) :: A
+      !! Coefficient matrix.
+      real(dp), intent(in) :: b(:, :)
+      !! Right-hand side vectors.
+      logical(lk), intent(in) :: refine
+      !! Iterative refinement of the solution?
+      real(dp), allocatable :: x(:, :)
+      !! Solution vectors.
+
+      ! General LAPACK variables.
+      integer(ilp) :: n, nrhs, info
+      ! LAPACK variables for LU decomposition.
+      real(dp), allocatable :: dl(:), d(:), du(:), du2(:)
+      integer(ilp), allocatable :: ipiv(:)
+      ! LAPACK variables for iterative refinement.
+      real(dp), allocatable :: ferr(:), berr(:), work(:)
+      integer(ilp), allocatable :: iwork(:)
+
+      ! Error handler.
+      type(linalg_state_type) :: err
+
+      ! Initialize data.
+      n = A%n; nrhs = size(b, 2); x = b
+
+      !------------------------------------
+      !-----     LU factorization     -----
+      !------------------------------------
+
+      ! ----- Allocations -----
+      allocate (du2(n - 2), ipiv(n))
+      dl = A%ev; d = A%dv; du = A%ev; 
+      ! ----- LU factorization -----
+      call gttrf(n, dl, d, du, du2, ipiv, info)
+      call handle_gttrf_info(err, info)
+
+      !-------------------------------------
+      !-----     Tridiagonal solve     -----
+      !-------------------------------------
+
+      ! ----- Solve the system -----
+      call gttrs("N", n, nrhs, dl, d, du, du2, ipiv, x, n, info)
+      call handle_gttrs_info(err, info)
+
+      !----------------------------------------
+      !-----     Iterative refinement     -----
+      !----------------------------------------
+
+      if (refine) then
+         ! ----- Allocate arrays -----
+         allocate (ferr(nrhs), berr(nrhs), work(3*n), iwork(n))
+         ! ----- Refinement step -----
+         call gtrfs("N", n, nrhs, A%ev, A%dv, A%ev, dl, d, du, du2, ipiv, b, &
+                    n, x, n, ferr, berr, work, iwork, info)
+      end if
+   end function symtridiagonal_solver
+
+   !-----------------------------------------------------------
+   !-----     Positive-definite SymTridiagonal Solver     -----
+   !-----------------------------------------------------------
+
+   ! Process PTTRF
+   elemental subroutine handle_pttrf_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRF return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by pttrf")
+      end select
+   end subroutine handle_pttrf_info
+
+   ! Process PTTRS
+   elemental subroutine handle_pttrs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by pttrs")
+      end select
+   end subroutine handle_pttrs_info
+
+   ! Process PTRFS
+   elemental subroutine handle_ptrfs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTRFS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by ptrfs")
+      end select
+   end subroutine handle_ptrfs_info
+
+   function posdef_symtridiagonal_solver(A, b, refine) result(x)
+      type(SymTridiagonal), intent(in) :: A
+      !! Coefficient matrix.
+      real(dp), intent(in) :: b(:, :)
+      !! Right-hand side vectors.
+      logical(lk), intent(in) :: refine
+      !! Iterative refinement of the solution?
+      real(dp), allocatable :: x(:, :)
+      !! Solution vectors.
+
+      ! General LAPACK variables.
+      integer(ilp) :: n, nrhs, info
+      ! LAPACK variables for LDL^T decomposition.
+      real(dp), allocatable :: dv(:), ev(:)
+      ! LAPACK variables for iterative refinement.
+      real(dp), allocatable :: ferr(:), berr(:), work(:)
+
+      ! Error handler.
+      type(linalg_state_type) :: err
+
+      ! Initialize data.
+      n = A%n; nrhs = size(b, 2); x = b
+
+      !------------------------------------
+      !-----     LU factorization     -----
+      !------------------------------------
+
+      ! ----- Allocations -----
+      ev = A%ev; dv = A%dv
+      ! ----- LDL^T factorization -----
+      call pttrf(n, dv, ev, info)
+      call handle_pttrf_info(err, info)
+
+      !-------------------------------------
+      !-----     Tridiagonal solve     -----
+      !-------------------------------------
+
+      ! ----- Solve the system -----
+      call pttrs(n, nrhs, dv, ev, x, n, info)
+      call handle_pttrs_info(err, info)
+
+      !----------------------------------------
+      !-----     Iterative refinement     -----
+      !----------------------------------------
+
+      if (refine) then
+         ! ----- Allocate arrays -----
+         allocate (ferr(nrhs), berr(nrhs), work(2*n))
+         ! ----- Refinement step -----
+         call ptrfs(n, nrhs, A%dv, A%ev, dv, ev, b, n, x, n, ferr, berr, work, info)
+      end if
+   end function posdef_symtridiagonal_solver
+
 end submodule

--- a/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
+++ b/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
@@ -146,14 +146,14 @@ module specialmatrices_symtridiagonal
       !! ```fortran
       !!    C = matmul(A, B)
       !! ```
-      pure module function spmv(A, x) result(y)
+      module function spmv(A, x) result(y)
          !! Compute the matrix-vector product \(y = Ax\) for a `SymTridiagonal` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
-         real(dp), intent(in) :: x(:)
+         real(dp), target, intent(in) :: x(:)
          !! Input vector.
-         real(dp), allocatable :: y(:)
+         real(dp), target, allocatable :: y(:)
          !! Output vector.
       end function
 

--- a/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
+++ b/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
@@ -197,19 +197,21 @@ module specialmatrices_symtridiagonal
       !!
       !! `x`   :  Solution of the linear system.
       !!          It has the same type and shape as `b`.
-      pure module function solve_single_rhs(A, b) result(x)
+      module function solve_single_rhs(A, b, refine) result(x)
          !! Solve the linear system \(Ax=b\) where \(A\) is of type `SymTridiagonal` and `b` a
          !! standard rank-1 array. The solution vector `x` has the same dimension and kind
          !! as the right-hand side vector `b`.
          type(SymTridiagonal), intent(in) :: A
          !! Coefficient matrix.
-         real(dp), intent(in) :: b(:)
+         real(dp), target, intent(in) :: b(:)
          !! Right-hand side vector.
+         logical(lk), optional, intent(in) :: refine
+         !! Whether iterative refinement of the solution is used or not.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
       end function
 
-      pure module function solve_multi_rhs(A, b) result(x)
+      module function solve_multi_rhs(A, b, refine) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type `SymTridiagonal` and `B` a
          !! standard rank-2 array. The solution matrix `X` has the same dimensions and kind
          !! as the right-hand side matrix `B`.
@@ -217,6 +219,8 @@ module specialmatrices_symtridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
          !! Right-hand side vectors.
+         logical(lk), optional, intent(in) :: refine
+         !! Whether iterative refinement of the solution is used or not.
          real(dp), allocatable, target :: x(:, :)
          !! Solution vectors.
       end function

--- a/src/Tridiagonal/matvecs.f90
+++ b/src/Tridiagonal/matvecs.f90
@@ -1,23 +1,36 @@
 submodule(specialmatrices_tridiagonal) tridiagonal_matvecs
+   use stdlib_linalg_lapack, only: lagtm
    implicit none(type, external)
 contains
    module procedure spmv
-   integer(ilp) :: i, n
-   n = A%n; allocate (y, mold=x)
-   y(1) = A%dv(1)*x(1) + A%du(1)*x(2)
-   do concurrent(i=2:n - 1)
-      y(i) = A%dl(i - 1)*x(i - 1) + A%dv(i)*x(i) + A%du(i)*x(i + 1)
-   end do
-   y(n) = A%dv(n)*x(n) + A%dl(n - 1)*x(n - 1)
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), allocatable :: dl(:), dv(:), du(:)
+   real(dp), pointer :: xmat(:, :), ymat(:, :)
+
+   ! Setup variables.
+   n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"
+   dl = A%dl; dv = A%dv; du = A%du
+   y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
+   
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
    end procedure
 
    module procedure spmvs
-   integer(ilp) :: i, j, n, nvecs
-   n = A%n; nvecs = size(x, 2); allocate (y, mold=x)
-   y(1, :) = A%dv(1)*x(1, :) + A%du(1)*x(2, :)
-   do concurrent(i=2:n - 1, j=1:nvecs)
-      y(i, j) = A%dl(i - 1)*x(i - 1, j) + A%dv(i)*x(i, j) + A%du(i)*x(i + 1, j)
-   end do
-   y(n, :) = A%dv(n)*x(n, :) + A%dl(n - 1)*x(n - 1, :)
+   ! Local variables.
+   character :: trans
+   integer(ilp) :: n, nrhs, ldx, ldy
+   real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
+   real(dp), allocatable :: dl(:), dv(:), du(:)
+
+   ! Setup variables.
+   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
+   dl = A%dl; dv = A%dv; du = A%du; y = x
+
+   ! Matrix-vector product.
+   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
    end procedure
 end submodule

--- a/src/Tridiagonal/matvecs.f90
+++ b/src/Tridiagonal/matvecs.f90
@@ -7,16 +7,14 @@ contains
    character :: trans
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
-   real(dp), allocatable :: dl(:), dv(:), du(:)
    real(dp), pointer :: xmat(:, :), ymat(:, :)
 
    ! Setup variables.
    n = A%n; nrhs = 1; ldx = n; ldy = n; trans = "N"
-   dl = A%dl; dv = A%dv; du = A%du
    y = x; xmat(1:n, 1:nrhs) => x; ymat(1:n, 1:nrhs) => y
-   
    ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, xmat, ldx, beta, ymat, ldy)
+   call lagtm(trans, n, nrhs, alpha, A%dl, A%dv, A%du, xmat, ldx, beta, ymat, ldy)
+
    end procedure
 
    module procedure spmvs
@@ -24,13 +22,11 @@ contains
    character :: trans
    integer(ilp) :: n, nrhs, ldx, ldy
    real(dp), parameter :: alpha = 1.0_dp, beta = 0.0_dp
-   real(dp), allocatable :: dl(:), dv(:), du(:)
 
    ! Setup variables.
-   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"
-   dl = A%dl; dv = A%dv; du = A%du; y = x
-
+   n = A%n; nrhs = size(x, 2); ldx = n; ldy = n; trans = "N"; y = x
    ! Matrix-vector product.
-   call lagtm(trans, n, nrhs, alpha, dl, dv, du, x, ldx, beta, y, ldy)
+   call lagtm(trans, n, nrhs, alpha, A%dl, A%dv, A%du, x, ldx, beta, y, ldy)
+
    end procedure
 end submodule

--- a/src/Tridiagonal/solve.f90
+++ b/src/Tridiagonal/solve.f90
@@ -9,16 +9,16 @@ contains
    ! Initialize arrays.
    n = A%n; nrhs = 1; dl = A%dl; d = A%dv; du = A%du
    x = b; xmat(1:n, 1:nrhs) => x
+   ! Solve system.
    call gtsv(n, nrhs, dl, d, du, xmat, n, info)
    end procedure
 
    module procedure solve_multi_rhs
    integer(ilp) :: i, n, nrhs, info
    real(dp), allocatable :: dl(:), d(:), du(:)
-   real(dp), pointer :: xmat(:, :)
    ! Initialize arrays.
-   n = A%n; nrhs = size(b, 2); dl = A%dl; d = A%dv; du = A%du
-   x = b; xmat(1:n, 1:nrhs) => x
-   call gtsv(n, nrhs, dl, d, du, xmat, n, info)
+   n = A%n; nrhs = size(b, 2); dl = A%dl; d = A%dv; du = A%du; x = b
+   ! Solve system.
+   call gtsv(n, nrhs, dl, d, du, x, n, info)
    end procedure
 end submodule

--- a/src/Tridiagonal/solve.f90
+++ b/src/Tridiagonal/solve.f90
@@ -1,6 +1,6 @@
 submodule(specialmatrices_tridiagonal) tridiagonal_linear_solver
    use stdlib_optval, only: optval
-   use stdlib_linalg_lapack, only: gtsv, gttrf, gttrs, gtrfs
+   use stdlib_linalg_lapack, only: gttrf, gttrs, gtrfs
    use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling, LINALG_ERROR, &
                                   LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR, LINALG_SUCCESS
    implicit none(type, external)

--- a/src/Tridiagonal/solve.f90
+++ b/src/Tridiagonal/solve.f90
@@ -1,24 +1,131 @@
 submodule(specialmatrices_tridiagonal) tridiagonal_linear_solver
-   use stdlib_linalg_lapack, only: gtsv
+   use stdlib_optval, only: optval
+   use stdlib_linalg_lapack, only: gtsv, gttrf, gttrs, gtrfs
+   use stdlib_linalg_state, only: linalg_state_type, linalg_error_handling, LINALG_ERROR, &
+                                  LINALG_INTERNAL_ERROR, LINALG_VALUE_ERROR, LINALG_SUCCESS
    implicit none(type, external)
+
+   character(*), parameter :: this = "tridiagonal_linear_solver"
 contains
+
+   ! Process GTTRF
+   elemental subroutine handle_gttrf_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRF return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gttrf")
+      end select
+   end subroutine handle_gttrf_info
+
+   ! Process GTTRS
+   elemental subroutine handle_gttrs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTTRS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gttrs")
+      end select
+   end subroutine handle_gttrs_info
+
+   ! Process GTRFS
+   elemental subroutine handle_gtrfs_info(err, info)
+      !> Error handler.
+      type(linalg_state_type), intent(inout) :: err
+      ! GTRFS return flag.
+      integer(ilp), intent(in) :: info
+
+      select case (info)
+      case (0)
+         ! Success.
+         err%state = LINALG_SUCCESS
+      case default
+         err = linalg_state_type(this, LINALG_INTERNAL_ERROR, "Unknown error returned by gtrfs")
+      end select
+   end subroutine handle_gtrfs_info
+
+   function tridiagonal_solver(A, b, refine) result(x)
+      type(Tridiagonal), intent(in) :: A
+      !! Coefficient matrix.
+      real(dp), intent(in) :: b(:, :)
+      !! Right-hand side vectors.
+      logical(lk), intent(in) :: refine
+      !! Iterative refinement of the solution?
+      real(dp), allocatable :: x(:, :)
+      !! Solution vectors.
+
+      ! General LAPACK variables.
+      integer(ilp) :: n, nrhs, info
+      ! LAPACK variables for LU decomposition.
+      real(dp), allocatable :: dl(:), d(:), du(:), du2(:)
+      integer(ilp), allocatable :: ipiv(:)
+      ! LAPACK variables for iterative refinement.
+      real(dp), allocatable :: ferr(:), berr(:), work(:)
+      integer(ilp), allocatable :: iwork(:)
+
+      ! Error handler.
+      type(linalg_state_type) :: err
+
+      ! Initialize data.
+      n = A%n; nrhs = size(b, 2); x = b
+
+      !------------------------------------
+      !-----     LU factorization     -----
+      !------------------------------------
+
+      ! ----- Allocations -----
+      allocate (du2(n - 2), ipiv(n))
+      dl = A%dl; d = A%dv; du = A%du; 
+      ! ----- LU factorization -----
+      call gttrf(n, dl, d, du, du2, ipiv, info)
+      call handle_gttrf_info(err, info)
+
+      !-------------------------------------
+      !-----     Tridiagonal solve     -----
+      !-------------------------------------
+
+      ! ----- Solve the system -----
+      call gttrs("N", n, nrhs, dl, d, du, du2, ipiv, x, n, info)
+      call handle_gttrs_info(err, info)
+
+      !----------------------------------------
+      !-----     Iterative refinement     -----
+      !----------------------------------------
+
+      if (refine) then
+         ! ----- Allocate arrays -----
+         allocate (ferr(nrhs), berr(nrhs), work(3*n), iwork(n))
+         ! ----- Refinement step -----
+         call gtrfs("N", n, nrhs, A%dl, A%dv, A%du, dl, d, du, du2, ipiv, b, &
+                    n, x, n, ferr, berr, work, iwork, info)
+      end if
+   end function tridiagonal_solver
+
    module procedure solve_single_rhs
-   integer(ilp) :: i, n, nrhs, info
-   real(dp), allocatable :: dl(:), d(:), du(:)
-   real(dp), pointer :: xmat(:, :)
-   ! Initialize arrays.
-   n = A%n; nrhs = 1; dl = A%dl; d = A%dv; du = A%du
-   x = b; xmat(1:n, 1:nrhs) => x
-   ! Solve system.
-   call gtsv(n, nrhs, dl, d, du, xmat, n, info)
+   ! Local variables.
+   logical(lk) :: refine_
+   real(dp), pointer :: xmat(:, :), bmat(:, :)
+   refine_ = optval(refine, .false.)
+   x = b; xmat(1:A%n, 1:1) => x; bmat(1:A%n, 1:1) => b
+   xmat = tridiagonal_solver(A, bmat, refine_)
    end procedure
 
    module procedure solve_multi_rhs
-   integer(ilp) :: i, n, nrhs, info
-   real(dp), allocatable :: dl(:), d(:), du(:)
-   ! Initialize arrays.
-   n = A%n; nrhs = size(b, 2); dl = A%dl; d = A%dv; du = A%du; x = b
-   ! Solve system.
-   call gtsv(n, nrhs, dl, d, du, x, n, info)
+   ! Local variables.
+   logical(lk) :: refine_
+   refine_ = optval(refine, .false.)
+   x = tridiagonal_solver(A, b, refine_)
    end procedure
 end submodule

--- a/src/Tridiagonal/specialmatrices_tridiagonal.f90
+++ b/src/Tridiagonal/specialmatrices_tridiagonal.f90
@@ -186,19 +186,21 @@ module specialmatrices_tridiagonal
       !!
       !! `x`   :  Solution of the linear system.
       !!          It has the same type and shape as `b`.
-      pure module function solve_single_rhs(A, b) result(x)
+      module function solve_single_rhs(A, b, refine) result(x)
          !! Solve the linear system \(Ax=b\) where \(A\) is of type `Tridiagonal` and `b` a
          !! standard rank-1 array. The solution vector `x` has the same dimension and kind
          !! as the right-hand side vector `b`.
          type(Tridiagonal), intent(in) :: A
          !! Coefficient matrix.
-         real(dp), intent(in) :: b(:)
+         real(dp), intent(in), target :: b(:)
          !! Right-hand side vector.
+         logical(lk), optional, intent(in) :: refine
+         !! Whether iterative refinement is used or not.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
       end function
 
-      pure module function solve_multi_rhs(A, b) result(x)
+      module function solve_multi_rhs(A, b, refine) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type `Tridiagonal` and `B` a
          !! standard rank-2 array. The solution matrix `X` has the same dimensions and kind
          !! as the right-hand side matrix `B`.
@@ -206,6 +208,8 @@ module specialmatrices_tridiagonal
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
          !! Right-hand side vectors.
+         logical(lk), optional, intent(in) :: refine
+         !! Whether iterative refined is used or not.
          real(dp), allocatable, target :: x(:, :)
          !! Solution vectors.
       end function

--- a/src/Tridiagonal/specialmatrices_tridiagonal.f90
+++ b/src/Tridiagonal/specialmatrices_tridiagonal.f90
@@ -135,14 +135,14 @@ module specialmatrices_tridiagonal
       !! ```fortran
       !!    C = matmul(A, B)
       !! ```
-      pure module function spmv(A, x) result(y)
+      module function spmv(A, x) result(y)
          !! Compute the matrix-vector product \(y = Ax\) for a `Tridiagonal` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
-         real(dp), intent(in) :: x(:)
+         real(dp), target, intent(in) :: x(:)
          !! Input vector.
-         real(dp), allocatable :: y(:)
+         real(dp), target, allocatable :: y(:)
          !! Output vector.
       end function
 

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -85,7 +85,7 @@ contains
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
-         x = solve(A, b)
+         x = solve(A, b, refine=.true.)
          ! Solve with stdlib (dense).
          x_stdlib = solve(dense(A), b)
          ! Check error.
@@ -100,7 +100,7 @@ contains
          ! Random rhs.
          call random_number(b)
          ! Solve with SpecialMatrices.
-         x = solve(A, b)
+         x = solve(A, b, refine=.true.)
          ! Solve with stdlib (dense).
          x_stdlib = solve(dense(A), b)
          ! Check error.


### PR DESCRIPTION
- Tridiagonal matmul now uses lagtm.
- SymTridiagonal matmul now uses lagtm.
- Bidiagonal matmul now uses lagtm.
- Removed unecessary allocations.
- Removed unecessary pointers in solve.
- Added tridiagonal solver with optional iterative refinement.
- Lapack solver + iterative refinement for SymTridiagonal.
