### PR TITLE
Partial support for Hankel matrices

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -21,5 +21,5 @@ source-form = "free"
 
 [dependencies]
 stdlib = "*"
-blas = "*"
+# blas = "*"
 fftpack = { git="https://github.com/nshalle/fftpack.git" }

--- a/fpm.toml
+++ b/fpm.toml
@@ -21,4 +21,5 @@ source-form = "free"
 
 [dependencies]
 stdlib = "*"
+blas = "*"
 fftpack = { git="https://github.com/nshalle/fftpack.git" }

--- a/src/Bidiagonal/constructors.f90
+++ b/src/Bidiagonal/constructors.f90
@@ -6,17 +6,17 @@ contains
    module procedure initialize
    A%n = n; allocate (A%dv(n)); allocate (A%ev(n - 1))
    A%dv = 0.0_dp; A%ev = 0.0_dp; A%which = "L"
-   end procedure
+   end procedure initialize
 
    module procedure construct
    integer(ilp) :: n
    n = size(dv)
    A%n = n; A%dv = dv; A%ev = ev; A%which = optval(which, "L")
-   end procedure
+   end procedure construct
 
    module procedure construct_constant
    integer(ilp) :: i
    A%n = n; A%which = optval(which, "L")
    A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n - 1)]
-   end procedure
-end submodule
+   end procedure construct_constant
+end submodule bidiagonal_constructors

--- a/src/Bidiagonal/det.f90
+++ b/src/Bidiagonal/det.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_bidiagonal) bidiagonal_determinant
 contains
    module procedure det_rdp
    d = product(A%dv)
-   end procedure
-end submodule
+   end procedure det_rdp
+end submodule bidiagonal_determinant

--- a/src/Bidiagonal/eig.f90
+++ b/src/Bidiagonal/eig.f90
@@ -4,11 +4,11 @@ submodule(specialmatrices_bidiagonal) bidiagonal_eigenvalue_decomposition
 contains
    module procedure eigvals_rdp
    lambda = stdlib_eigvals(dense(A))
-   end procedure
+   end procedure eigvals_rdp
 
    module procedure eig_rdp
    real(dp), allocatable :: Amat(:, :)
    Amat = dense(A)
    call stdlib_eig(Amat, lambda, right=right, left=left, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure eig_rdp
+end submodule bidiagonal_eigenvalue_decomposition

--- a/src/Bidiagonal/matvecs.f90
+++ b/src/Bidiagonal/matvecs.f90
@@ -20,6 +20,8 @@ contains
       call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, xmat, ldx, beta, ymat, ldy)
    case ("U")
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
+   case default
+      error stop "Provided uplo param is neither U nor L."
    end select
 
    end procedure spmv
@@ -40,6 +42,8 @@ contains
       call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, dummy, x, ldx, beta, y, ldy)
    case ("U")
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, x, ldx, beta, y, ldy)
+   case default
+      error stop "Provided uplo param is neither U nor L."
    end select
 
    end procedure spmvs

--- a/src/Bidiagonal/matvecs.f90
+++ b/src/Bidiagonal/matvecs.f90
@@ -22,7 +22,7 @@ contains
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
    end select
 
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    ! Local variables.
@@ -42,5 +42,5 @@ contains
       call lagtm(trans, n, nrhs, alpha, dummy, A%dv, A%ev, x, ldx, beta, y, ldy)
    end select
 
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule bidiagonal_matvecs

--- a/src/Bidiagonal/solve.f90
+++ b/src/Bidiagonal/solve.f90
@@ -50,6 +50,8 @@ contains
       dv = A%dv; dl = A%ev; du = 0.0_dp*A%ev
    case ("U")
       dv = A%dv; dl = 0.0_dp*A%ev; du = A%ev
+   case default
+      error stop "Provided uplo param is neither U nor L."
    end select
    ! Solve.
    call gtsv(n, nrhs, dl, dv, du, xmat, n, info)
@@ -68,6 +70,8 @@ contains
       dv = A%dv; dl = A%ev; du = 0.0_dp*A%ev
    case ("U")
       dv = A%dv; dl = 0.0_dp*A%ev; du = A%ev
+   case default
+      error stop "Provided uplo param is neither U nor L."
    end select
    ! Solve.
    call gtsv(n, nrhs, dl, dv, du, x, n, info)

--- a/src/Bidiagonal/solve.f90
+++ b/src/Bidiagonal/solve.f90
@@ -54,7 +54,7 @@ contains
    ! Solve.
    call gtsv(n, nrhs, dl, dv, du, xmat, n, info)
    call handle_gtsv_info(n, nrhs, n, info, err0)
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
    type(linalg_state_type) :: err0
@@ -72,5 +72,5 @@ contains
    ! Solve.
    call gtsv(n, nrhs, dl, dv, du, x, n, info)
    call handle_gtsv_info(n, nrhs, n, info, err0)
-   end procedure
-end submodule
+   end procedure solve_multi_rhs
+end submodule bidiagonal_linear_solver

--- a/src/Bidiagonal/specialmatrices_bidiagonal.f90
+++ b/src/Bidiagonal/specialmatrices_bidiagonal.f90
@@ -33,7 +33,7 @@ module specialmatrices_bidiagonal
       !! Bidiagonal elements of the matrix.
       character :: which
       !! Whether `A` is lower- or upper-bidiagonal.
-   end type
+   end type Bidiagonal
 
    !--------------------------------
    !-----     Constructors     -----
@@ -117,7 +117,7 @@ module specialmatrices_bidiagonal
          !! Dimension of the matrix.
          type(Bidiagonal) :: A
          !! Symmetric Bidiagonal matrix.
-      end function
+      end function initialize
 
       pure module function construct(dv, ev, which) result(A)
          !! Construct a `Bidiagonal` matrix from the rank-1 arrays `dv`
@@ -128,7 +128,7 @@ module specialmatrices_bidiagonal
          !! Whether `A` is lower- or upper-diagonal.
          type(Bidiagonal) :: A
          !! Bidiagonal matrix.
-      end function
+      end function construct
 
       pure module function construct_constant(d, e, n, which) result(A)
          !! Construct a `Bidiagonal` matrix with constant diagonal elements.
@@ -140,7 +140,7 @@ module specialmatrices_bidiagonal
          !! Whether `A` is lower- or upper-bidiagonal.
          type(Bidiagonal) :: A
          !! Symmetric Bidiagonal matrix.
-      end function
+      end function construct_constant
    end interface
 
    !-------------------------------------------------------------------
@@ -170,7 +170,7 @@ module specialmatrices_bidiagonal
          !! Input vector.
          real(dp), target, allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Bidiagonal`
@@ -182,7 +182,7 @@ module specialmatrices_bidiagonal
          !! Input vectors.
          real(dp), allocatable :: Y(:, :)
          !! Output vectors.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -221,7 +221,7 @@ module specialmatrices_bidiagonal
          !! Right-hand side vector.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, b) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type
@@ -233,7 +233,7 @@ module specialmatrices_bidiagonal
          !! Right-hand side vectors.
          real(dp), allocatable, target :: x(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    interface inv
@@ -243,7 +243,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
          !! Inverse of `A`.
-      end function
+      end function inv_rdp
    end interface
 
    !-----------------------------------------
@@ -273,7 +273,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          real(dp) :: d
          !! Determinant of the matrix.
-      end function
+      end function det_rdp
    end interface
 
    interface trace
@@ -298,7 +298,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          real(dp) :: tr
          !! Trace of the matrix.
-      end function
+      end function trace_rdp
    end interface
 
    !------------------------------------------------
@@ -328,7 +328,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -369,7 +369,7 @@ module specialmatrices_bidiagonal
          !! Left singular vectors as columns.
          real(dp), optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -400,7 +400,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvals_rdp
    end interface
 
    interface eig
@@ -444,7 +444,7 @@ module specialmatrices_bidiagonal
          !! Eigenvalues.
          complex(dp), optional, intent(out) :: right(:, :), left(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eig_rdp
    end interface
 
    !-------------------------------------
@@ -474,7 +474,7 @@ module specialmatrices_bidiagonal
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -500,7 +500,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          type(Bidiagonal) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -513,7 +513,7 @@ module specialmatrices_bidiagonal
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -523,7 +523,7 @@ module specialmatrices_bidiagonal
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -544,4 +544,4 @@ module specialmatrices_bidiagonal
       end function scalar_multiplication_bis_rdp
    end interface
 
-end module
+end module specialmatrices_bidiagonal

--- a/src/Bidiagonal/specialmatrices_bidiagonal.f90
+++ b/src/Bidiagonal/specialmatrices_bidiagonal.f90
@@ -113,6 +113,7 @@ module specialmatrices_bidiagonal
       !! @endnote
       pure module function initialize(n) result(A)
          !! Construct a `Bidiagonal` matrix filled with zeros.
+         implicit none(type, external)
          integer(ilp), intent(in) :: n
          !! Dimension of the matrix.
          type(Bidiagonal) :: A
@@ -122,6 +123,7 @@ module specialmatrices_bidiagonal
       pure module function construct(dv, ev, which) result(A)
          !! Construct a `Bidiagonal` matrix from the rank-1 arrays `dv`
          !! and `ev`.
+         implicit none(type, external)
          real(dp), intent(in) :: dv(:), ev(:)
          !! Bidiagonal elements of the matrix.
          character, optional, intent(in) :: which
@@ -132,6 +134,7 @@ module specialmatrices_bidiagonal
 
       pure module function construct_constant(d, e, n, which) result(A)
          !! Construct a `Bidiagonal` matrix with constant diagonal elements.
+         implicit none(type, external)
          real(dp), intent(in) :: d, e
          !! Bidiagonal elements of the matrix.
          integer(ilp), intent(in) :: n
@@ -164,6 +167,7 @@ module specialmatrices_bidiagonal
          !! Compute the matrix-vector product \(y = Ax\) for a `Bidiagonal`
          !! matrix \(A\). Both `x` and `y` are rank-1 arrays with the same
          !! kind as `A`.
+         implicit none(type, external)
          type(Bidiagonal), target, intent(in) :: A
          !! Input matrix.
          real(dp), target, intent(in) :: x(:)
@@ -176,6 +180,7 @@ module specialmatrices_bidiagonal
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Bidiagonal`
          !! matrix \(A\) and a dense matrix \(X\) (rank-2 array). \(Y\) is
          !! also a rank-2 array with the same dimensions as \(X\).
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
@@ -215,6 +220,7 @@ module specialmatrices_bidiagonal
          !! Solve the linear system \(Ax=b\) where \(A\) is of type
          !! `Bidiagonal` and `b` a standard rank-1 array. The solution
          !! vector `x` has the same dimension and kind as `b`.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -227,6 +233,7 @@ module specialmatrices_bidiagonal
          !! Solve the linear system \(AX=B\) where \(A\) is of type
          !! `Bidiagonal` and `B` a standard rank-2 array. The solution matrix
          !! `X` has the same dimensions and kind as `B`.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
@@ -239,6 +246,7 @@ module specialmatrices_bidiagonal
    interface inv
       pure module function inv_rdp(A) result(B)
          !! Utility function to compute the inverse of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
@@ -269,6 +277,7 @@ module specialmatrices_bidiagonal
       !! - `d` :  Determinant of the matrix.
       pure module function det_rdp(A) result(d)
          !! Compute the determinant of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: d
@@ -294,6 +303,7 @@ module specialmatrices_bidiagonal
       !! - `tr`:  Trace of the matrix.
       pure module function trace_rdp(A) result(tr)
          !! Compute the trace of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: tr
@@ -324,6 +334,7 @@ module specialmatrices_bidiagonal
       !! - `s` :  Vector of singular values sorted in decreasing order.
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -361,6 +372,7 @@ module specialmatrices_bidiagonal
       !!                      `intent(out)` argument.
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: s(:)
@@ -396,6 +408,7 @@ module specialmatrices_bidiagonal
       module function eigvals_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real
          !! `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
@@ -438,6 +451,7 @@ module specialmatrices_bidiagonal
       module subroutine eig_rdp(A, lambda, left, right)
          !! Utility function to compute the eigenvalues and eigenvectors of a
          !! `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          complex(dp), intent(out) :: lambda(:)
@@ -470,6 +484,7 @@ module specialmatrices_bidiagonal
       module function dense_rdp(A) result(B)
          !! Utility function to convert a `Bidiagonal` matrix to a
          !! rank-2 array.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -496,6 +511,7 @@ module specialmatrices_bidiagonal
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `Bidiagonal`
          !! matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          type(Bidiagonal) :: B
@@ -507,6 +523,7 @@ module specialmatrices_bidiagonal
       pure module function size_rdp(A, dim) result(arr_size)
          !! Utility function to return the size of `Bidiagonal` matrix along
          !! a given dimension.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -519,6 +536,7 @@ module specialmatrices_bidiagonal
    interface shape
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of a `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -530,6 +548,7 @@ module specialmatrices_bidiagonal
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Bidiagonal` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Bidiagonal), intent(in) :: A
          type(Bidiagonal) :: B
@@ -538,6 +557,7 @@ module specialmatrices_bidiagonal
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Bidiagonal` matrix.
+         implicit none(type, external)
          type(Bidiagonal), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Bidiagonal) :: B

--- a/src/Bidiagonal/svd.f90
+++ b/src/Bidiagonal/svd.f90
@@ -4,11 +4,11 @@ submodule(specialmatrices_bidiagonal) bidiagonal_singular_value_decomposition
 contains
    module procedure svdvals_rdp
    s = stdlib_svdvals(dense(A))
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
    real(dp), allocatable :: Amat(:, :)
    Amat = dense(A)
    call stdlib_svd(Amat, s, u, vt, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure svd_rdp
+end submodule bidiagonal_singular_value_decomposition

--- a/src/Bidiagonal/trace.f90
+++ b/src/Bidiagonal/trace.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_bidiagonal) bidiagonal_trace
 contains
    module procedure trace_rdp
    tr = sum(A%dv)
-   end procedure
-end submodule
+   end procedure trace_rdp
+end submodule bidiagonal_trace

--- a/src/Bidiagonal/utils.f90
+++ b/src/Bidiagonal/utils.f90
@@ -18,7 +18,7 @@ contains
       end do
       B(n, n) = A%dv(n)
    end select
-   end procedure
+   end procedure dense_rdp
 
    module procedure transpose_rdp
    B = A
@@ -27,22 +27,22 @@ contains
    else
       B%which = "L"
    end if
-   end procedure
+   end procedure transpose_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
+   end procedure size_rdp
 
    module procedure scalar_multiplication_rdp
    B = Bidiagonal(alpha*A%dv, alpha*A%ev, A%which)
-   end procedure
+   end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
    B = Bidiagonal(alpha*A%dv, alpha*A%ev, A%which)
-   end procedure
+   end procedure scalar_multiplication_bis_rdp
 
-end submodule
+end submodule bidiagonal_utils

--- a/src/Bidiagonal/utils.f90
+++ b/src/Bidiagonal/utils.f90
@@ -17,6 +17,8 @@ contains
          B(i, i + 1) = A%ev(i)
       end do
       B(n, n) = A%dv(n)
+   case default
+      error stop "Provided uplo param is neither U nor L."
    end select
    end procedure dense_rdp
 

--- a/src/Circulant/constructors.f90
+++ b/src/Circulant/constructors.f90
@@ -7,5 +7,5 @@ contains
    n = size(c) ; A%n = n; A%c = c
    !> Fourier Transform of the generating vector.
    A%c_hat = fft(cmplx(c, kind=dp), n)
-   end procedure
-end submodule
+   end procedure construct
+end submodule circulant_constructors

--- a/src/Circulant/constructors.f90
+++ b/src/Circulant/constructors.f90
@@ -4,7 +4,7 @@ contains
    module procedure construct
    integer(ilp) :: n
    !> Initialize the standard matrix data.
-   n = size(c) ; A%n = n; A%c = c
+   n = size(c); A%n = n; A%c = c
    !> Fourier Transform of the generating vector.
    A%c_hat = fft(cmplx(c, kind=dp), n)
    end procedure construct

--- a/src/Circulant/eig.f90
+++ b/src/Circulant/eig.f90
@@ -4,7 +4,7 @@ submodule(specialmatrices_circulant) circulant_eigenvalue_decomposition
 contains
    module procedure eigvals_rdp
    lambda = A%c_hat
-   end procedure
+   end procedure eigvals_rdp
 
    module procedure eig_rdp
    real(dp), allocatable :: Amat(:, :)
@@ -25,5 +25,5 @@ contains
          left(:, i) = ifft(left(:, i), n) / sqrt(1.0_dp*n)
       enddo
    endif
-   end procedure
-end submodule
+   end procedure eig_rdp
+end submodule circulant_eigenvalue_decomposition

--- a/src/Circulant/eig.f90
+++ b/src/Circulant/eig.f90
@@ -14,16 +14,16 @@ contains
    if (present(right)) then
       right = eye(n, mold=1.0_dp)
       do concurrent(i=1:n)
-         right(:, i) = fft(right(:, i), n) / sqrt(1.0_dp*n)
-      enddo
+         right(:, i) = fft(right(:, i), n)/sqrt(1.0_dp*n)
+      end do
       right = hermitian(right)
-   endif
+   end if
 
    if (present(left)) then
       left = eye(n, mold=1.0_dp)
       do concurrent(i=1:n)
-         left(:, i) = ifft(left(:, i), n) / sqrt(1.0_dp*n)
-      enddo
-   endif
+         left(:, i) = ifft(left(:, i), n)/sqrt(1.0_dp*n)
+      end do
+   end if
    end procedure eig_rdp
 end submodule circulant_eigenvalue_decomposition

--- a/src/Circulant/inv.f90
+++ b/src/Circulant/inv.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_circulant) circulant_inverse
 contains
    module procedure inv_rdp
    B = circulant(real(ifft(1.0_dp/A%c_hat)) / A%n)
-   end procedure
-end submodule
+   end procedure inv_rdp
+end submodule circulant_inverse

--- a/src/Circulant/inv.f90
+++ b/src/Circulant/inv.f90
@@ -2,6 +2,6 @@ submodule(specialmatrices_circulant) circulant_inverse
    implicit none(type, external)
 contains
    module procedure inv_rdp
-   B = circulant(real(ifft(1.0_dp/A%c_hat)) / A%n)
+   B = circulant(real(ifft(1.0_dp/A%c_hat))/A%n)
    end procedure inv_rdp
 end submodule circulant_inverse

--- a/src/Circulant/matvecs.f90
+++ b/src/Circulant/matvecs.f90
@@ -2,16 +2,16 @@ submodule(specialmatrices_circulant) circulant_matvecs
    implicit none(type, external)
 contains
    module procedure spmv
-      integer(ilp) :: i
-      y = x
-      y = real(ifft(fft(cmplx(y, kind=dp), A%n) * A%c_hat, A%n)) / A%n
+   integer(ilp) :: i
+   y = x
+   y = real(ifft(fft(cmplx(y, kind=dp), A%n)*A%c_hat, A%n))/A%n
    end procedure spmv
 
    module procedure spmvs
-      integer(ilp) :: i
-      y = x
-      do concurrent(i=1:size(x, 2))
+   integer(ilp) :: i
+   y = x
+   do concurrent(i=1:size(x, 2))
       y(:, i) = matmul(A, x(:, i))
-      enddo
+   end do
    end procedure spmvs
 end submodule circulant_matvecs

--- a/src/Circulant/matvecs.f90
+++ b/src/Circulant/matvecs.f90
@@ -5,7 +5,7 @@ contains
       integer(ilp) :: i
       y = x
       y = real(ifft(fft(cmplx(y, kind=dp), A%n) * A%c_hat, A%n)) / A%n
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
       integer(ilp) :: i
@@ -13,5 +13,5 @@ contains
       do concurrent(i=1:size(x, 2))
       y(:, i) = matmul(A, x(:, i))
       enddo
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule circulant_matvecs

--- a/src/Circulant/solve.f90
+++ b/src/Circulant/solve.f90
@@ -2,14 +2,14 @@ submodule(specialmatrices_circulant) circulant_linear_solver
    implicit none(type, external)
 contains
    module procedure solve_single_rhs
-      x = real(ifft(fft(cmplx(b, kind=dp), A%n) / A%c_hat, A%n)) / A%n
+   x = real(ifft(fft(cmplx(b, kind=dp), A%n)/A%c_hat, A%n))/A%n
    end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
-      integer(ilp) :: i
-      x = b
-      do concurrent(i=1:size(b, 2))
-         x(:, i) = solve(A, b(:, i))
-      enddo
+   integer(ilp) :: i
+   x = b
+   do concurrent(i=1:size(b, 2))
+      x(:, i) = solve(A, b(:, i))
+   end do
    end procedure solve_multi_rhs
 end submodule circulant_linear_solver

--- a/src/Circulant/solve.f90
+++ b/src/Circulant/solve.f90
@@ -3,7 +3,7 @@ submodule(specialmatrices_circulant) circulant_linear_solver
 contains
    module procedure solve_single_rhs
       x = real(ifft(fft(cmplx(b, kind=dp), A%n) / A%c_hat, A%n)) / A%n
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
       integer(ilp) :: i
@@ -11,5 +11,5 @@ contains
       do concurrent(i=1:size(b, 2))
          x(:, i) = solve(A, b(:, i))
       enddo
-   end procedure
-end submodule
+   end procedure solve_multi_rhs
+end submodule circulant_linear_solver

--- a/src/Circulant/specialmatrices_circulant.f90
+++ b/src/Circulant/specialmatrices_circulant.f90
@@ -32,7 +32,7 @@ module specialmatrices_circulant
       !! Generating vector.
       complex(dp), allocatable :: c_hat(:)
       !! Fourier Transform of the generating vector.
-   end type
+   end type Circulant
 
    !--------------------------------
    !-----     Constructors     -----
@@ -74,7 +74,7 @@ module specialmatrices_circulant
          !! Generating vector.
          type(Circulant) :: A
          !! Corresponding Circulant matrix.
-      end function
+      end function construct
    end interface
 
    !-------------------------------------------------------------------
@@ -103,7 +103,7 @@ module specialmatrices_circulant
          !! Input vector.
          real(dp), allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Circulant` matrix `A`.
@@ -114,7 +114,7 @@ module specialmatrices_circulant
          !! Input matrix.
          real(dp), allocatable :: y(:, :)
          !! Output matrix.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -159,7 +159,7 @@ module specialmatrices_circulant
          !! Right-hand side vector.
          real(dp), allocatable :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, B) result(X)
          !! Solve the linear system \(AX=B\), where `A` is `Circulant` and
@@ -171,7 +171,7 @@ module specialmatrices_circulant
          !! Right-hand side vectors.
          real(dp), allocatable :: X(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    interface inv
@@ -182,7 +182,7 @@ module specialmatrices_circulant
          !! Input matrix.
          type(Circulant) :: B
          !! Inverse of `A`.
-      end function
+      end function inv_rdp
    end interface
 
    !------------------------------------------------
@@ -211,7 +211,7 @@ module specialmatrices_circulant
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -257,7 +257,7 @@ module specialmatrices_circulant
          !! Left singular vectors as columns.
          real(dp), optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -293,7 +293,7 @@ module specialmatrices_circulant
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvals_rdp
    end interface
 
    interface eig
@@ -337,7 +337,7 @@ module specialmatrices_circulant
          !! Eigenvalues.
          complex(dp), optional, intent(out) :: right(:, :), left(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eig_rdp
    end interface
 
    !-------------------------------------
@@ -365,7 +365,7 @@ module specialmatrices_circulant
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -390,7 +390,7 @@ module specialmatrices_circulant
          !! Input matrix.
          type(Circulant) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -405,7 +405,7 @@ module specialmatrices_circulant
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -416,7 +416,7 @@ module specialmatrices_circulant
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -436,4 +436,4 @@ module specialmatrices_circulant
          type(Circulant) :: B
       end function scalar_multiplication_bis_rdp
    end interface
-end module
+end module specialmatrices_circulant

--- a/src/Circulant/specialmatrices_circulant.f90
+++ b/src/Circulant/specialmatrices_circulant.f90
@@ -70,6 +70,7 @@ module specialmatrices_circulant
       !! @endnote
       pure module function construct(c) result(A)
          !! Construct a `Circulant` matrix from the rank-1 array `c`.
+         implicit none(type, external)
          real(dp), intent(in) :: c(:)
          !! Generating vector.
          type(Circulant) :: A
@@ -97,6 +98,7 @@ module specialmatrices_circulant
       pure module function spmv(A, x) result(y)
          !! Compute the matrix-vector product for a `Circulant` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:)
@@ -108,6 +110,7 @@ module specialmatrices_circulant
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Circulant` matrix `A`.
          !! Both `X` and `Y` are rank-2 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:, :)
@@ -153,6 +156,7 @@ module specialmatrices_circulant
          !! Solve the linear system \(Ax=b\) where \(A\) is `Circulant` and
          !! `b` a standard rank-1 array. The solution vector `x` has the same
          !! dimension and kind as the right-hand side vector `b`.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -165,6 +169,7 @@ module specialmatrices_circulant
          !! Solve the linear system \(AX=B\), where `A` is `Circulant` and
          !! `B` is a rank-2 array. The solution matrix `X` has the same
          !! dimension and kind as the right-hand side matrix `B`.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
@@ -178,6 +183,7 @@ module specialmatrices_circulant
       pure module function inv_rdp(A) result(B)
          !! Utility function to compute the inverse of a `Circulant` matrix.
          !! If `A` is circulant, its inverse also is circulant.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          type(Circulant) :: B
@@ -207,6 +213,7 @@ module specialmatrices_circulant
       !! - `s` :  Vector of singular values sorted in decreasing order.
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -249,6 +256,7 @@ module specialmatrices_circulant
       !! @endnote
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: s(:)
@@ -289,6 +297,7 @@ module specialmatrices_circulant
       module function eigvals_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real `Circulant`
          !! matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
@@ -331,6 +340,7 @@ module specialmatrices_circulant
       module subroutine eig_rdp(A, lambda, left, right)
          !! Utility function to compute the eigenvalues and eigenvectors of a
          !! `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          complex(dp), intent(out) :: lambda(:)
@@ -361,6 +371,7 @@ module specialmatrices_circulant
       !! - `B` :  Rank-2 array representation of the matrix \( A \).
       module function dense_rdp(A) result(B)
          !! Utility function to convert a `Circulant` matrix to a rank-2 array.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -386,6 +397,7 @@ module specialmatrices_circulant
       !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          type(Circulant) :: B
@@ -399,6 +411,7 @@ module specialmatrices_circulant
       pure module function size_rdp(A, dim) result(arr_size)
          !! Utility function to return the size of `Circulant` matrix along a
          !! given dimension.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -412,6 +425,7 @@ module specialmatrices_circulant
       !! Utility function to return the shape of a `Circulant` matrix.
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of a `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -423,6 +437,7 @@ module specialmatrices_circulant
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Circulant` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Circulant), intent(in) :: A
          type(Circulant) :: B
@@ -431,6 +446,7 @@ module specialmatrices_circulant
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Circulant` matrix.
+         implicit none(type, external)
          type(Circulant), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Circulant) :: B

--- a/src/Circulant/svd.f90
+++ b/src/Circulant/svd.f90
@@ -8,7 +8,7 @@ contains
       s = abs(A%c_hat)
       !> Sort in decreasing order.
       call sort(s, reverse=.true.)
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
       integer(ilp) :: i, n
@@ -32,7 +32,7 @@ contains
       !> Sort the SVD.
       allocate(indices(n)) ; call sort_index(s, indices, reverse=.true.)
       u = u(:, indices) ; vt = vt(indices, :)
-   end procedure
+   end procedure svd_rdp
 
    pure function discrete_hartley_transform(F)  result(H)
       complex(dp), intent(in) :: F(:, :)
@@ -40,5 +40,5 @@ contains
       real(dp), allocatable :: H(:, :)
       !! Hartley transform of F.
       H = F%re + F%im
-   end function
-end submodule
+   end function discrete_hartley_transform
+end submodule circulant_svd

--- a/src/Circulant/svd.f90
+++ b/src/Circulant/svd.f90
@@ -1,40 +1,40 @@
-submodule (specialmatrices_circulant) circulant_svd
+submodule(specialmatrices_circulant) circulant_svd
    use stdlib_sorting, only: sort, sort_index
    use stdlib_linalg, only: diag, hermitian
    implicit none(type, external)
 contains
    module procedure svdvals_rdp
-      !> Analytic expression for the singular values.
-      s = abs(A%c_hat)
-      !> Sort in decreasing order.
-      call sort(s, reverse=.true.)
+   !> Analytic expression for the singular values.
+   s = abs(A%c_hat)
+   !> Sort in decreasing order.
+   call sort(s, reverse=.true.)
    end procedure svdvals_rdp
 
    module procedure svd_rdp
-      integer(ilp) :: i, n
-      integer(ilp), allocatable :: indices(:)
-      complex(dp), allocatable :: lambda(:), left(:, :), right(:, :)
-      complex(dp), allocatable :: pi(:, :), D(:, :)
-      !> Matrix dimension.
-      n = A%n
-      !> Allocate variables.
-      allocate(lambda(n), left(n, n), right(n, n))
-      !> Eigendecomposition of the Circulant matrix.
-      call eig(A, lambda, right=right, left=left) ; left = hermitian(left)
-      !> Singular values.
-      s = abs(A%c_hat)
-      !> Right singular vectors.
-      vt = discrete_hartley_transform(left)
-      !> Left singular vectors.
-      pi = matmul(transpose(left), left) ; D = diag(A%c_hat/s)
-      u = discrete_hartley_transform(left)
-      u = matmul(u, real(D%re - matmul(pi, D%im)))
-      !> Sort the SVD.
-      allocate(indices(n)) ; call sort_index(s, indices, reverse=.true.)
-      u = u(:, indices) ; vt = vt(indices, :)
+   integer(ilp) :: i, n
+   integer(ilp), allocatable :: indices(:)
+   complex(dp), allocatable :: lambda(:), left(:, :), right(:, :)
+   complex(dp), allocatable :: pi(:, :), D(:, :)
+   !> Matrix dimension.
+   n = A%n
+   !> Allocate variables.
+   allocate (lambda(n), left(n, n), right(n, n))
+   !> Eigendecomposition of the Circulant matrix.
+   call eig(A, lambda, right=right, left=left); left = hermitian(left)
+   !> Singular values.
+   s = abs(A%c_hat)
+   !> Right singular vectors.
+   vt = discrete_hartley_transform(left)
+   !> Left singular vectors.
+   pi = matmul(transpose(left), left); D = diag(A%c_hat/s)
+   u = discrete_hartley_transform(left)
+   u = matmul(u, real(D%re - matmul(pi, D%im)))
+   !> Sort the SVD.
+   allocate (indices(n)); call sort_index(s, indices, reverse=.true.)
+   u = u(:, indices); vt = vt(indices, :)
    end procedure svd_rdp
 
-   pure function discrete_hartley_transform(F)  result(H)
+   pure function discrete_hartley_transform(F) result(H)
       complex(dp), intent(in) :: F(:, :)
       !! Input matrix.
       real(dp), allocatable :: H(:, :)

--- a/src/Circulant/utils.f90
+++ b/src/Circulant/utils.f90
@@ -7,7 +7,7 @@ contains
    do concurrent(j=1:n)
       B(:, j) = cshift(A%c, -j+1)
    enddo
-   end procedure
+   end procedure dense_rdp
 
    module procedure transpose_rdp
    real(dp), allocatable :: b_vec(:)
@@ -15,22 +15,22 @@ contains
    n = A%n
    b_vec = A%c(n:1:-1) ; b_vec = cshift(b_vec, -1)
    B = Circulant(b_vec)
-   end procedure
+   end procedure transpose_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
+   end procedure size_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure scalar_multiplication_rdp
    B = Circulant(alpha*A%c)
-   end procedure
+   end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
    B = Circulant(alpha*A%c)
-   end procedure
+   end procedure scalar_multiplication_bis_rdp
 
-end submodule
+end submodule circulant_utilities

--- a/src/Circulant/utils.f90
+++ b/src/Circulant/utils.f90
@@ -3,17 +3,17 @@ submodule(specialmatrices_circulant) circulant_utilities
 contains
    module procedure dense_rdp
    integer(ilp) :: j, n
-   n = A%n ; allocate(B(n, n)) ; B = 0.0_dp
+   n = A%n; allocate (B(n, n)); B = 0.0_dp
    do concurrent(j=1:n)
-      B(:, j) = cshift(A%c, -j+1)
-   enddo
+      B(:, j) = cshift(A%c, -j + 1)
+   end do
    end procedure dense_rdp
 
    module procedure transpose_rdp
    real(dp), allocatable :: b_vec(:)
    integer(ilp) :: n
    n = A%n
-   b_vec = A%c(n:1:-1) ; b_vec = cshift(b_vec, -1)
+   b_vec = A%c(n:1:-1); b_vec = cshift(b_vec, -1)
    B = Circulant(b_vec)
    end procedure transpose_rdp
 

--- a/src/Diagonal/constructors.f90
+++ b/src/Diagonal/constructors.f90
@@ -5,21 +5,21 @@ contains
    module procedure initialize
    ! Utility function to construct a `Diagonal` matrix filled with zeros.
    A%n = n; allocate (A%dv(n)); A%dv = 0.0_dp
-   end procedure
+   end procedure initialize
 
    module procedure construct
    ! Utility function to construct a `Diagonal` matrix from a rank-1 array.
    A%n = size(dv); A%dv = dv
-   end procedure
+   end procedure construct
 
    module procedure construct_constant
    ! Utility function to construct a `Diagonal` matrix with constant value.
    integer(ilp) :: i
    A%n = n; A%dv = [(d, i=1, n)]
-   end procedure
+   end procedure construct_constant
 
    module procedure dense_to_diag
    ! Utility function to construct a `Diagonal` matrix from a rank-2 array.
    B = Diagonal(diag(A))
-   end procedure
-end submodule
+   end procedure dense_to_diag
+end submodule diagonal_constructors

--- a/src/Diagonal/det.f90
+++ b/src/Diagonal/det.f90
@@ -4,5 +4,5 @@ contains
    module procedure det_rdp
    ! Compute det(A).
    d = product(A%dv)
-   end procedure
-end submodule
+   end procedure det_rdp
+end submodule diagonal_determinant

--- a/src/Diagonal/eigh.f90
+++ b/src/Diagonal/eigh.f90
@@ -5,7 +5,7 @@ submodule(specialmatrices_diagonal) diagonal_hermitian_eigenvalue_decomposition
 contains
    module procedure eigvalsh_rdp
    lambda = A%dv; call sort(lambda)
-   end procedure
+   end procedure eigvalsh_rdp
 
    module procedure eigh_rdp
    integer(ilp) :: index(A%n)
@@ -15,5 +15,5 @@ contains
    if (present(vectors)) then
       vectors = eye(A%n); vectors = vectors(:, index)
    end if
-   end procedure
-end submodule
+   end procedure eigh_rdp
+end submodule diagonal_hermitian_eigenvalue_decomposition

--- a/src/Diagonal/inv.f90
+++ b/src/Diagonal/inv.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_diagonal) diagonal_inverse
 contains
    module procedure inv_rdp
    B = Diagonal(1.0_dp/A%dv)
-   end procedure
-end submodule
+   end procedure inv_rdp
+end submodule diagonal_inverse

--- a/src/Diagonal/matvecs.f90
+++ b/src/Diagonal/matvecs.f90
@@ -8,7 +8,7 @@ contains
    do concurrent(i=1:size(x))
       y(i) = A%dv(i)*x(i)
    end do
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    ! Utility function to compute multiple matrix-vector products.
@@ -17,5 +17,5 @@ contains
    do concurrent(i=1:size(x, 1), j=1:size(x, 2))
       y(i, j) = A%dv(i)*x(i, j)
    end do
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule diagonal_matvecs

--- a/src/Diagonal/solve.f90
+++ b/src/Diagonal/solve.f90
@@ -8,7 +8,7 @@ contains
    do concurrent(i=1:A%n)
       x(i) = b(i)/A%dv(i)
    end do
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
    ! Solve \(AX = B\).
@@ -18,5 +18,5 @@ contains
    do concurrent(i=1:A%n, j=1:size(b, 2))
       x(i, j) = b(i, j)*inv_dv(i)
    end do
-   end procedure
-end submodule
+   end procedure solve_multi_rhs
+end submodule diagonal_linear_solver

--- a/src/Diagonal/specialmatrices_diagonal.f90
+++ b/src/Diagonal/specialmatrices_diagonal.f90
@@ -30,7 +30,7 @@ module specialmatrices_diagonal
       !! Dimension of the matrix.
       real(dp), allocatable :: dv(:)
       !! Diagonal elements of the matrix.
-   end type
+   end type Diagonal
 
    !--------------------------------
    !-----     Constructors     -----
@@ -141,7 +141,7 @@ module specialmatrices_diagonal
    !-------------------------------------------------------------------
 
    interface matmul
-      !! This interface overloads the Fortran intrinsic `matmul` for a 
+      !! This interface overloads the Fortran intrinsic `matmul` for a
       !! `Diagonal` matrix, both for matrix-vector and matrix-matrix
       !! products. For a matrix-matrix product \( C = AB \), only the matrix
       !! \( A \) has to be a `Diagonal` matrix. Both \( B \) and \( C \)
@@ -163,7 +163,7 @@ module specialmatrices_diagonal
          !! Input vector.
          real(dp), allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product \(Y = AX\) for a `Diagonal`
@@ -175,7 +175,7 @@ module specialmatrices_diagonal
          !! Input vectors.
          real(dp), allocatable :: Y(:, :)
          !! Output vectors.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -214,7 +214,7 @@ module specialmatrices_diagonal
          !! Right-hand side vector.
          real(dp), allocatable :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, b) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type
@@ -227,7 +227,7 @@ module specialmatrices_diagonal
          !! Right-hand side vectors.
          real(dp), allocatable :: X(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    interface inv
@@ -237,7 +237,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          type(Diagonal) :: B
          !! Inverse of `A`.
-      end function
+      end function inv_rdp
    end interface
 
    !-----------------------------------------
@@ -267,7 +267,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          real(dp) :: d
          !! Determinant of the matrix.
-      end function
+      end function det_rdp
    end interface
 
    interface trace
@@ -292,7 +292,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          real(dp) :: tr
          !! Trace of the matrix.
-      end function
+      end function trace_rdp
    end interface
 
    !------------------------------------------------
@@ -322,7 +322,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -363,7 +363,7 @@ module specialmatrices_diagonal
          !! Left singular vectors as columns.
          real(dp), allocatable, optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -394,7 +394,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvalsh_rdp
    end interface
 
    interface eigh
@@ -428,7 +428,7 @@ module specialmatrices_diagonal
          !! Eigenvalues.
          real(dp), allocatable, optional, intent(out) :: vectors(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eigh_rdp
    end interface
 
    !-------------------------------------
@@ -457,7 +457,7 @@ module specialmatrices_diagonal
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -482,7 +482,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          type(Diagonal) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -495,7 +495,7 @@ module specialmatrices_diagonal
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -505,7 +505,7 @@ module specialmatrices_diagonal
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -525,4 +525,4 @@ module specialmatrices_diagonal
          type(Diagonal) :: B
       end function scalar_multiplication_bis_rdp
    end interface
-end module
+end module specialmatrices_diagonal

--- a/src/Diagonal/specialmatrices_diagonal.f90
+++ b/src/Diagonal/specialmatrices_diagonal.f90
@@ -1,6 +1,6 @@
 module specialmatrices_diagonal
    use stdlib_linalg_constants, only: dp, ilp
-   implicit none
+   implicit none(type, external)
    private
 
    ! --> Linear Algebra.
@@ -98,6 +98,7 @@ module specialmatrices_diagonal
       pure module function initialize(n) result(A)
          !! Utility function to construct a `Diagonal` matrix filled with
          !! zeros.
+         implicit none(type, external)
          integer(ilp), intent(in) :: n
          !! Dimension of the matrix.
          type(Diagonal) :: A
@@ -107,6 +108,7 @@ module specialmatrices_diagonal
       pure module function construct(dv) result(A)
          !! Utility function to construct a `Diagonal` matrix from a rank-1
          !! array.
+         implicit none(type, external)
          real(dp), intent(in) :: dv(:)
          !! Diagonal elements of the matrix.
          type(Diagonal) :: A
@@ -116,6 +118,7 @@ module specialmatrices_diagonal
       pure module function construct_constant(d, n) result(A)
          !! Utility function to construct a `Diagonal` matrix with constant
          !! diagonal element.
+         implicit none(type, external)
          real(dp), intent(in) :: d
          !! Constant diagonal element of the matrix.
          integer(ilp), intent(in) :: n
@@ -128,6 +131,7 @@ module specialmatrices_diagonal
          !! Utility function to construct a `Diagonal` matrix from a rank-2
          !! array. The resulting matrix is constructed from the diagonal
          !! element of the input matrix, even if the latter is not diagonal.
+         implicit none(type, external)
          real(dp), intent(in) :: A(:, :)
          !! Dense \(n \times n\) matrix from which to construct the
          !! `Diagonal` one.
@@ -157,6 +161,7 @@ module specialmatrices_diagonal
          !! Compute the matrix-vector product \(y = Ax\) for a `Diagonal`
          !! matrix \(A\). Both `x` and `y` are rank-1 arrays with the same
          !! kind as `A`.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:)
@@ -169,6 +174,7 @@ module specialmatrices_diagonal
          !! Compute the matrix-matrix product \(Y = AX\) for a `Diagonal`
          !! matrix \(A\) and a dense matrix \(X\) (rank-2 array). \(Y\) is
          !! also a rank-2 array with the same dimensions as \(X\).
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
@@ -208,6 +214,7 @@ module specialmatrices_diagonal
          !! `Diagonal` and `b` a standard rank-1 array. The solution vector
          !! `x` has the same dimension and kind as the right-hand side
          !! vector `b`.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -221,6 +228,7 @@ module specialmatrices_diagonal
          !! `Diagonal` and `B` a standard rank-2 array. The solution matrix
          !! `X` has the same dimensions and kind as the right-hand side
          !! matrix `B`.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
@@ -233,6 +241,7 @@ module specialmatrices_diagonal
    interface inv
       pure module function inv_rdp(A) result(B)
          !! Utility function to compute the inverse of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          type(Diagonal) :: B
@@ -263,6 +272,7 @@ module specialmatrices_diagonal
       !! - `d` :  Determinant of the matrix.
       pure module function det_rdp(A) result(d)
          !! Compute the determinant of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: d
@@ -288,6 +298,7 @@ module specialmatrices_diagonal
       !! - `tr`:  Trace of the matrix.
       pure module function trace_rdp(A) result(tr)
          !! Compute the trace of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: tr
@@ -318,6 +329,7 @@ module specialmatrices_diagonal
       !! - `s` :  Vector of singular values sorted in decreasing order.
       pure module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -355,6 +367,7 @@ module specialmatrices_diagonal
       !!                   argument.
       module subroutine svd_rdp(A, u, s, vt)
          !! Compute the singular value decomposition of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out) :: s(:)
@@ -390,6 +403,7 @@ module specialmatrices_diagonal
       module function eigvalsh_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real `Diagonal`
          !! matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
@@ -422,6 +436,7 @@ module specialmatrices_diagonal
       module subroutine eigh_rdp(A, lambda, vectors)
          !! Utility function to compute the eigenvalues and eigenvectors of
          !! a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out) :: lambda(:)
@@ -453,6 +468,7 @@ module specialmatrices_diagonal
       !! - `B` :  Rank-2 array representation of the matrix \( A \).
       module function dense_rdp(A) result(B)
          !! Convert a `Diagonal` matrix to a rank-2 array.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -478,6 +494,7 @@ module specialmatrices_diagonal
       !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          type(Diagonal) :: B
@@ -489,6 +506,7 @@ module specialmatrices_diagonal
       pure module function size_rdp(A, dim) result(arr_size)
          !! Utility function to return the size of `Diagonal` matrix along a
          !! given dimension.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -501,6 +519,7 @@ module specialmatrices_diagonal
    interface shape
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of a `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -512,6 +531,7 @@ module specialmatrices_diagonal
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Diagonal` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Diagonal), intent(in) :: A
          type(Diagonal) :: B
@@ -520,6 +540,7 @@ module specialmatrices_diagonal
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Utility function to perform a scalar multiplication with a
          !! `Diagonal` matrix.
+         implicit none(type, external)
          type(Diagonal), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Diagonal) :: B

--- a/src/Diagonal/svd.f90
+++ b/src/Diagonal/svd.f90
@@ -5,7 +5,7 @@ submodule(specialmatrices_diagonal) diagonal_singular_value_decomposition
 contains
    module procedure svdvals_rdp
    s = abs(A%dv); call sort(s, reverse=.true.)
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
    integer(ilp) :: i, index(A%n)
@@ -19,5 +19,5 @@ contains
       vt(i, i) = -1.0_dp
    end do
    vt = vt(index, :)
-   end procedure
-end submodule
+   end procedure svd_rdp
+end submodule diagonal_singular_value_decomposition

--- a/src/Diagonal/trace.f90
+++ b/src/Diagonal/trace.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_diagonal) diagonal_trace
 contains
    module procedure trace_rdp
    tr = sum(A%dv)
-   end procedure
-end submodule
+   end procedure trace_rdp
+end submodule diagonal_trace

--- a/src/Diagonal/utils.f90
+++ b/src/Diagonal/utils.f90
@@ -4,26 +4,26 @@ submodule(specialmatrices_diagonal) diagonal_utilities
 contains
    module procedure dense_rdp
    B = diag(A%dv)
-   end procedure
+   end procedure dense_rdp
 
    module procedure transpose_rdp
    B = A
-   end procedure
+   end procedure transpose_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
+   end procedure size_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure scalar_multiplication_rdp
    B = Diagonal(alpha*A%dv)
-   end procedure
+   end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
    B = Diagonal(alpha*A%dv)
-   end procedure
+   end procedure scalar_multiplication_bis_rdp
 
-end submodule
+end submodule diagonal_utilities

--- a/src/Hankel/constructors.f90
+++ b/src/Hankel/constructors.f90
@@ -1,0 +1,12 @@
+submodule(specialmatrices_hankel) hankel_constructors
+   implicit none(type, external)
+contains
+   module procedure construct
+   !> Dimension of the matrix.
+   A%m = size(vc) ; A%n = size(vr)
+   !> First column/Last row vectors.
+   A%vc = vc ; A%vr = vr
+   !> Ensure vc[end] and vr[1] are the same.
+   A%vr(A%m) = A%vc(1)
+   end procedure construct
+end submodule hankel_constructors

--- a/src/Hankel/constructors.f90
+++ b/src/Hankel/constructors.f90
@@ -2,11 +2,13 @@ submodule(specialmatrices_hankel) hankel_constructors
    implicit none(type, external)
 contains
    module procedure construct
+   !> Sanity check.
+   if (size(v) < m + n - 1) then
+      error stop "Dimension of v is inconsistent with that of H."
+   end if
    !> Dimension of the matrix.
-   A%m = size(vc) ; A%n = size(vr)
-   !> First column/Last row vectors.
-   A%vc = vc ; A%vr = vr
-   !> Ensure vc[end] and vr[1] are the same.
-   A%vr(A%m) = A%vc(1)
+   A%m = m; A%n = n
+   !> Generating vector.
+   A%v = v(1:m + n - 1)
    end procedure construct
 end submodule hankel_constructors

--- a/src/Hankel/matvecs.f90
+++ b/src/Hankel/matvecs.f90
@@ -1,0 +1,15 @@
+submodule(specialmatrices_hankel) hankel_matvecs
+   implicit none(type, external)
+contains
+   module procedure spmv
+   integer(ilp) :: m, n
+   m = A%m; n = A%n
+   y = matmul(Toeplitz(A%v(n:), A%v(n:1:-1)), x(n:1:-1))
+   end procedure spmv
+
+   module procedure spmvs
+   integer(ilp) :: m, n
+   m = A%m; n = A%n
+   y = matmul(Toeplitz(A%v(n:), A%v(n:1:-1)), x(n:1:-1, :))
+   end procedure spmvs
+end submodule hankel_matvecs

--- a/src/Hankel/specialmatrices_hankel.f90
+++ b/src/Hankel/specialmatrices_hankel.f90
@@ -1,0 +1,462 @@
+module specialmatrices_hankel
+   use stdlib_linalg_constants, only: dp, ilp, lk
+   use stdlib_linalg, only: eig, eigvals, svd, svdvals
+   use specialmatrices_toeplitz
+   implicit none(type, external)
+   private
+
+   ! --> Linear algebra
+   public :: transpose
+   public :: matmul
+   public :: solve
+   public :: svd, svdvals
+   public :: eigh, eigvalsh
+
+   ! --> Utility functions.
+   public :: Toeplitz
+   public :: dense
+   public :: shape
+   public :: size
+   public :: operator(*)
+
+   !---------------------------------------------------
+   !-----     Base type for Hankel matrices     -----
+   !---------------------------------------------------
+
+   type, public :: Hankel
+      !! Base type to define a `Hankel` matrix of size [m x n]. The first
+      !! column is given by the vector `vc` while the first row is given by
+      !! `vr`.
+      private
+      integer(ilp) :: m, n
+      !! Dimensions of the matrix.
+      real(dp), allocatable :: vc(:)
+      !! First column of the matrix.
+      real(dp), allocatable :: vr(:)
+      !! Last row of the matrix.
+   end type
+
+   !--------------------------------
+   !-----     Constructors     -----
+   !--------------------------------
+
+   interface Hankel
+      !! This interface provides methods to construct `Hankel` matrices.
+      !! Given a vector `vc` specifying the first column of the matrix and a
+      !! vector `vr` specifying its last row, the associated `Hankel`
+      !! matrix is the following \(m \times n\) matrix
+      !!
+      !! \[
+      !!    A
+      !!    =
+      !!    \begin{bmatrix}
+      !!       h_0      &  h_1      &  \cdots   &  h_{(n-1)}      \\
+      !!       h_1      &  h_0      &  \cdots   &  \vdots   \\
+      !!       \vdots   &  \ddots   &  \ddots   &  h_{n-1+m-2}      \\
+      !!       h_{m-1}      &  \cdots   &  t_1      &  h_{n+m-2}
+      !!    \end{bmatrix}.
+      !! \]
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    integer, parameter :: m = 100, n = 200
+      !!    real(dp) :: vc(n), vr(n)
+      !!    type(Hankel) :: A
+      !!
+      !!    call random_number(vc) ; call random_number(vr)
+      !!    A = hankel(Hc, vr)
+      !! ```
+      !!
+      !! @warning
+      !! The element \( A_{m1} \) is read from the last entry of the vector
+      !! `vc`. The first entry of `vr` is not referenced.
+      !! @endwarning
+      !!
+      !! @note
+      !! Only `double precision` is currently supported for this matrix type.
+      !! @endnote
+      pure module function construct(vc, vr) result(A)
+         !! Construct a `Hankel` matrix from the rank-1 arrays `vc` and `vr`.
+         real(dp), intent(in) :: vc(:)
+         !! First column of the matrix.
+         real(dp), intent(in) :: vr(:)
+         !! Last row of the matrix.
+         type(Hankel) :: A
+         !! Corresponding hankel matrix.
+      end function
+   end interface
+
+   interface Toeplitz
+      !! Utility function to transform an m x n `Hankel` matrix into an
+      !! m x n `Toeplitz` matrix.
+      pure module function Hankel2Toeplitz(H) result(T)
+         type(Hankel), intent(in) :: H
+         type(Toeplitz) :: T
+      end function
+   end interface
+
+   !-------------------------------------------------------------------
+   !-----     Matrix-vector and Matrix-matrix multiplications     -----
+   !-------------------------------------------------------------------
+
+   interface matmul
+      !! This interface overloads the Fortran intrinsic `matmul` for a
+      !! `Hankel` matrix, both for matrix-vector and matrix-matrix products.
+      !! For a matrix-matrix product \( C = AB \), only the matrix \( A \)
+      !! has to be a `Hankel` matrix. Both \( B \) and \( C \) need to be
+      !! standard Fortran rank-2 arrays. All the underlying functions are
+      !! defined as `pure`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    y = matmul(A, x)
+      !! ```
+      !!
+      !! @note
+      !! Matrix-vector products for `Hankel` matrices can be efficiently
+      !! computed by transforming the matrix into a `Toeplitz` one and
+      !! embedding the `Toeplitz` matrix into a `Circulant` matrix of size
+      !! `[m+n x m+n]` and using the Fast Fourier Transform provided
+      !! by `fftpack`.
+      !! @endnote
+      pure module function spmv(A, x) result(y)
+         !! Compute the matrix-vector product for a `Hankel` matrix \(A\).
+         !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(in) :: x(:)
+         !! Input vector.
+         real(dp), allocatable :: y(:)
+         !! Output vector.
+      end function
+
+      pure module function spmvs(A, X) result(Y)
+         !! Compute the matrix-matrix product for a `Hankel` matrix `A`.
+         !! Both `X` and `Y` are rank-2 arrays with the same kind as `A`.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(in) :: x(:, :)
+         !! Input matrix.
+         real(dp), allocatable :: y(:, :)
+         !! Output matrix.
+      end function
+   end interface
+
+   !-----------------------------------------------
+   !-----     Linear systems of equations     -----
+   !-----------------------------------------------
+
+   interface solve
+      !! This interface overloads the `solve` interface from `stdlib_linalg`
+      !! for solving a linear system \( Ax = b \) where \( A \) is a `Hankel`
+      !! matrix. It also enables to solve a linear system with multiple
+      !! right-hand sides.
+      !!
+      !! #### Syntax
+      !!
+      !! To solve a system with \( A \) being of type `Hankel`:
+      !!
+      !! ```fortran
+      !!    x = solve(A, b)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  Matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `b` :  Rank-1 or rank-2 array defining the right-hand side(s).
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `x` :  Solution of the linear system.
+      !!          It has the same type and shape as `b`.
+      !!
+      !! @note
+      !! Under the hood, a `gmres` solver is being used along with a
+      !! Circulant preconditioner. By design, `gmres` is run until a
+      !! relative tolerance of \(10^{-8}\) is reached.
+      !! @endnote
+      pure module function solve_single_rhs(A, b) result(x)
+         !! Solve the linear system \(Ax=b\) where \(A\) is `Hankel` and `b`
+         !! a standard rank-1 array. The solution vector `x` has the same
+         !! dimension and kind as the right-hand side vector `b`.
+         type(Hankel), intent(in) :: A
+         !! Coefficient matrix.
+         real(dp), intent(in) :: b(:)
+         !! Right-hand side vector.
+         real(dp), allocatable :: x(:)
+         !! Solution vector.
+      end function
+
+      pure module function solve_multi_rhs(A, B) result(X)
+         !! Solve the linear system \(AX=B\), where `A` is `Hankel` and `B`
+         !! is a rank-2 array. The solution matrix `X` has the same dimension
+         !! and kind as the right-hand side matrix `B`.
+         type(Hankel), intent(in) :: A
+         !! Coefficient matrix.
+         real(dp), intent(in) :: B(:, :)
+         !! Right-hand side vectors.
+         real(dp), allocatable :: X(:, :)
+         !! Solution vectors.
+      end function
+   end interface
+
+   !------------------------------------------------
+   !-----     Singular Value Decomposition     -----
+   !------------------------------------------------
+
+   interface svdvals
+      !! This interface overloads the `svdvals` interface from `stdlib_linalg`
+      !! to compute the singular values of a `Hankel` matrix \(A\).
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    s = svdvals(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  Matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `s` :  Vector of singular values sorted in decreasing order.
+      !!
+      !! @note
+      !! No analytic expression exist for the singular values of a general
+      !! `Hankel` matrix. Under the hood, the matrix `A` is converted to
+      !! its dense representation and the function `svdvals` from
+      !! `stdlib_linalg` is used.
+      !! @endnote
+      module function svdvals_rdp(A) result(s)
+         !! Compute the singular values of a `hankel` matrix.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable :: s(:)
+         !! Singular values in descending order.
+      end function
+   end interface
+
+   interface svd
+      !! This interface overloads the `svd` interface from `stdlib_linalg` to
+      !! compute the the singular value decomposition of a `Hankel` matrix
+      !! \(A\).
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    call svd(A, s, u, vt)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  Matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `s` :  Rank-1 array `real` array returning the singular values of
+      !!          `A`. It is an `intent(out)` argument.
+      !!
+      !! - `u` (optional)  :  Rank-2 array of the same kind as `A` returning
+      !!                      the left singular vectors of `A` as columns. Its
+      !!                      size should be `[n, n]`.
+      !!                      It is an `intent(out)` argument.
+      !!
+      !! - `vt` (optional) :  Rank-2 array of the same kind as `A` returning
+      !!                      the right singular vectors of `A` as rows. Its
+      !!                      size should be `[n, n]`. It is an `intent(out)`
+      !!                      argument.
+      !!
+      !! @note
+      !! No analytic expression exist for the singular value of a general
+      !! `Hankel` matrix. Under the hood, the matrix `A` is converted to
+      !! its dense representation and the function `svdvals` from
+      !! `stdlib_linalg` is used.
+      !! @endnote
+      module subroutine svd_rdp(A, s, u, vt)
+         !! Compute the singular value decomposition of a `Hankel` matrix.
+         type(hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(out) :: s(:)
+         !! Singular values in descending order.
+         real(dp), optional, intent(out) :: u(:, :)
+         !! Left singular vectors as columns.
+         real(dp), optional, intent(out) :: vt(:, :)
+         !! Right singular vectors as rows.
+      end subroutine
+   end interface
+
+   !--------------------------------------------
+   !-----     Eigenvalue Decomposition     -----
+   !--------------------------------------------
+
+   interface eigvalsh
+      !! This interface overloads the `eigvals` interface from `stdlib_linalg`
+      !! to compute the eigenvalues of a real-valued matrix \( A \) whose
+      !! type is `Hankel`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    lambda = eigvals(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  `real`-valued matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `lambda` :  Vector of eigenvalues in increasing order.
+      !!
+      !! @note
+      !! No analytic expression exist for the eigenvalues of a general
+      !! `Hankel` matrix. Under the hood, the matrix `A` is converted to
+      !! its dense representation and the function `eigvals` from
+      !! `stdlib_linalg` is used.
+      !! @endnote
+      module function eigvalsh_rdp(A) result(lambda)
+         !! Utility function to compute the eigenvalues of a real `Hankel`
+         !! matrix.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), allocatable :: lambda(:)
+         !! Eigenvalues.
+      end function
+   end interface
+
+   interface eigh
+      !! This interface overloads the `eigh` interface from `stdlib_linalg` to
+      !! compute the eigenvalues and eigenvectors of a real-valued matrix
+      !! \(A\) whose type is `Hankel`.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    call eigh(A, lambda [, left] [, right])
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` : `real`-valued matrix of `Hankel`.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `lambda`  :  Rank-1 `real` array returning the eigenvalues of `A`
+      !!                in increasing order.
+      !!                It is an `intent(out)` argument.
+      !!
+      !! - `vectors` (optional)  :  `real` rank-2 array of the same kind as `A`
+      !!                            returning the left eigenvectors of `A`.
+      !!                            It is an `intent(out)` argument.
+      !!
+      !! @note
+      !! No analytic expression exist for the eigendecomposition of a general
+      !! `hankel` matrix. Under the hood, the matrix `A` is converted to
+      !! its dense representation and the function `eigh` from
+      !! `stdlib_linalg` is used.
+      !! @endnote
+      module subroutine eigh_rdp(A, lambda, vectors)
+         !! Utility function to compute the eigenvalues and eigenvectors of a
+         !! `Hankel` matrix.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         real(dp), intent(out) :: lambda(:)
+         !! Eigenvalues.
+         real(dp), optional, intent(out) :: vectors(:, :)
+         !! Eigenvectors.
+      end subroutine
+   end interface
+
+   !-------------------------------------
+   !-----     Utility functions     -----
+   !-------------------------------------
+
+   interface dense
+      !! Convert a `Hankel` matrix to a standard rank-2 array.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    B = dense(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  Matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `B` :  Rank-2 array representation of the matrix \( A \).
+      pure module function dense_rdp(A) result(B)
+         !! Utility function to convert a `Hankel` matrix to a rank-2 array.
+         type(Hankel), intent(in) :: A
+         !! Input diagonal matrix.
+         real(dp), allocatable :: B(:, :)
+         !! Output dense rank-2 array.
+      end function
+   end interface
+
+   interface transpose
+      !! This interface overloads the Fortran `intrinsic` procedure to define
+      !! the transpose operation of a `Hankel` matrix.
+      !!
+      !! #### Syntax
+      !!
+      !! ```fortran
+      !!    B = transpose(A)
+      !! ```
+      !!
+      !! #### Arguments
+      !!
+      !! - `A` :  Matrix of `Hankel` type.
+      !!          It is an `intent(in)` argument.
+      !!
+      !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
+      pure module function transpose_rdp(A) result(B)
+         !! Utility function to compute the transpose of a `hankel` matrix.
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         type(Hankel) :: B
+         !! Transpose of the matrix.
+      end function
+   end interface
+
+   interface size
+      !! Utility function to return the size of `Hankel` matrix along a
+      !! given dimension.
+      pure module function size_rdp(A, dim) result(arr_size)
+         type(Hankel), intent(in) :: A
+         !! Input matrix.
+         integer(ilp), optional, intent(in) :: dim
+         !! Queried dimension.
+         integer(ilp) :: arr_size
+         !! Size of the matrix along the dimension dim.
+      end function
+   end interface
+
+   interface shape
+      !! Utility function to return the size of a `Hankel` matrix.
+      pure module function shape_rdp(A) result(arr_shape)
+         !! Utility function to get the shape of a `Hankel` matrix.
+         type(hankel), intent(in) :: A
+         !! Input matrix.
+         integer(ilp) :: arr_shape(2)
+         !! Shape of the matrix.
+      end function
+   end interface
+
+   interface operator(*)
+      pure module function scalar_multiplication_rdp(alpha, A) result(B)
+         !! Utility function to perform a scalar multiplication with a `Hankel` matrix.
+         real(dp), intent(in) :: alpha
+         type(Hankel), intent(in) :: A
+         type(Hankel) :: B
+      end function scalar_multiplication_rdp
+
+      pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
+         !! Utility function to perform a scalar multiplication with a `Hankel` matrix.
+         type(Hankel), intent(in) :: A
+         real(dp), intent(in) :: alpha
+         type(Hankel) :: B
+      end function scalar_multiplication_bis_rdp
+   end interface
+end module

--- a/src/Hankel/specialmatrices_hankel.f90
+++ b/src/Hankel/specialmatrices_hankel.f90
@@ -34,7 +34,7 @@ module specialmatrices_hankel
       !! First column of the matrix.
       real(dp), allocatable :: vr(:)
       !! Last row of the matrix.
-   end type
+   end type Hankel
 
    !--------------------------------
    !-----     Constructors     -----
@@ -84,7 +84,7 @@ module specialmatrices_hankel
          !! Last row of the matrix.
          type(Hankel) :: A
          !! Corresponding hankel matrix.
-      end function
+      end function construct
    end interface
 
    interface Toeplitz
@@ -93,7 +93,7 @@ module specialmatrices_hankel
       pure module function Hankel2Toeplitz(H) result(T)
          type(Hankel), intent(in) :: H
          type(Toeplitz) :: T
-      end function
+      end function Hankel2Toeplitz
    end interface
 
    !-------------------------------------------------------------------
@@ -130,7 +130,7 @@ module specialmatrices_hankel
          !! Input vector.
          real(dp), allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Hankel` matrix `A`.
@@ -141,7 +141,7 @@ module specialmatrices_hankel
          !! Input matrix.
          real(dp), allocatable :: y(:, :)
          !! Output matrix.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -188,7 +188,7 @@ module specialmatrices_hankel
          !! Right-hand side vector.
          real(dp), allocatable :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, B) result(X)
          !! Solve the linear system \(AX=B\), where `A` is `Hankel` and `B`
@@ -200,7 +200,7 @@ module specialmatrices_hankel
          !! Right-hand side vectors.
          real(dp), allocatable :: X(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    !------------------------------------------------
@@ -236,7 +236,7 @@ module specialmatrices_hankel
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -284,7 +284,7 @@ module specialmatrices_hankel
          !! Left singular vectors as columns.
          real(dp), optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -322,7 +322,7 @@ module specialmatrices_hankel
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvalsh_rdp
    end interface
 
    interface eigh
@@ -364,7 +364,7 @@ module specialmatrices_hankel
          !! Eigenvalues.
          real(dp), optional, intent(out) :: vectors(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eigh_rdp
    end interface
 
    !-------------------------------------
@@ -392,7 +392,7 @@ module specialmatrices_hankel
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -417,7 +417,7 @@ module specialmatrices_hankel
          !! Input matrix.
          type(Hankel) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -430,7 +430,7 @@ module specialmatrices_hankel
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -441,7 +441,7 @@ module specialmatrices_hankel
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -459,4 +459,4 @@ module specialmatrices_hankel
          type(Hankel) :: B
       end function scalar_multiplication_bis_rdp
    end interface
-end module
+end module specialmatrices_hankel

--- a/src/Hankel/specialmatrices_hankel.f90
+++ b/src/Hankel/specialmatrices_hankel.f90
@@ -1,7 +1,7 @@
 module specialmatrices_hankel
    use stdlib_linalg_constants, only: dp, ilp, lk
    use stdlib_linalg, only: eig, eigvals, svd, svdvals
-   use specialmatrices_toeplitz
+   use specialmatrices_toeplitz, only: Toeplitz, matmul
    implicit none(type, external)
    private
 
@@ -112,6 +112,7 @@ module specialmatrices_hankel
       pure module function spmv(A, x) result(y)
          !! Compute the matrix-vector product for a `Hankel` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:)
@@ -123,6 +124,7 @@ module specialmatrices_hankel
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Hankel` matrix `A`.
          !! Both `X` and `Y` are rank-2 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:, :)
@@ -170,6 +172,7 @@ module specialmatrices_hankel
          !! Solve the linear system \(Ax=b\) where \(A\) is `Hankel` and `b`
          !! a standard rank-1 array. The solution vector `x` has the same
          !! dimension and kind as the right-hand side vector `b`.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -182,6 +185,7 @@ module specialmatrices_hankel
          !! Solve the linear system \(AX=B\), where `A` is `Hankel` and `B`
          !! is a rank-2 array. The solution matrix `X` has the same dimension
          !! and kind as the right-hand side matrix `B`.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
@@ -220,6 +224,7 @@ module specialmatrices_hankel
       !! @endnote
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `hankel` matrix.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -264,6 +269,7 @@ module specialmatrices_hankel
       !! @endnote
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `Hankel` matrix.
+         implicit none(type, external)
          type(hankel), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: s(:)
@@ -306,6 +312,7 @@ module specialmatrices_hankel
       module function eigvalsh_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real `Hankel`
          !! matrix.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
@@ -346,6 +353,7 @@ module specialmatrices_hankel
       module subroutine eigh_rdp(A, lambda, vectors)
          !! Utility function to compute the eigenvalues and eigenvectors of a
          !! `Hankel` matrix.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: lambda(:)
@@ -376,6 +384,7 @@ module specialmatrices_hankel
       !! - `B` :  Rank-2 array representation of the matrix \( A \).
       pure module function dense_rdp(A) result(B)
          !! Utility function to convert a `Hankel` matrix to a rank-2 array.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -401,6 +410,7 @@ module specialmatrices_hankel
       !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `hankel` matrix.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          type(Hankel) :: B
@@ -412,6 +422,7 @@ module specialmatrices_hankel
       !! Utility function to return the size of `Hankel` matrix along a
       !! given dimension.
       pure module function size_rdp(A, dim) result(arr_size)
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -425,6 +436,7 @@ module specialmatrices_hankel
       !! Utility function to return the size of a `Hankel` matrix.
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of a `Hankel` matrix.
+         implicit none(type, external)
          type(hankel), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -435,6 +447,7 @@ module specialmatrices_hankel
    interface operator(*)
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Utility function to perform a scalar multiplication with a `Hankel` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Hankel), intent(in) :: A
          type(Hankel) :: B
@@ -442,6 +455,7 @@ module specialmatrices_hankel
 
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Utility function to perform a scalar multiplication with a `Hankel` matrix.
+         implicit none(type, external)
          type(Hankel), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Hankel) :: B

--- a/src/Hankel/specialmatrices_hankel.f90
+++ b/src/Hankel/specialmatrices_hankel.f90
@@ -13,7 +13,6 @@ module specialmatrices_hankel
    public :: eigh, eigvalsh
 
    ! --> Utility functions.
-   public :: Toeplitz
    public :: dense
    public :: shape
    public :: size
@@ -24,16 +23,13 @@ module specialmatrices_hankel
    !---------------------------------------------------
 
    type, public :: Hankel
-      !! Base type to define a `Hankel` matrix of size [m x n]. The first
-      !! column is given by the vector `vc` while the first row is given by
-      !! `vr`.
+      !! Base type to define a `Hankel` matrix of size [m x n] generate from
+      !! the vector v.
       private
       integer(ilp) :: m, n
       !! Dimensions of the matrix.
-      real(dp), allocatable :: vc(:)
-      !! First column of the matrix.
-      real(dp), allocatable :: vr(:)
-      !! Last row of the matrix.
+      real(dp), allocatable :: v(:)
+      !! Generating vector.
    end type Hankel
 
    !--------------------------------
@@ -76,24 +72,16 @@ module specialmatrices_hankel
       !! @note
       !! Only `double precision` is currently supported for this matrix type.
       !! @endnote
-      pure module function construct(vc, vr) result(A)
+      pure module function construct(v, m, n) result(A)
+         implicit none(type, external)
          !! Construct a `Hankel` matrix from the rank-1 arrays `vc` and `vr`.
-         real(dp), intent(in) :: vc(:)
-         !! First column of the matrix.
-         real(dp), intent(in) :: vr(:)
-         !! Last row of the matrix.
+         real(dp), intent(in) :: v(:)
+         !! Generating vector.
+         integer(ilp), intent(in) :: m, n
+         !! Dimensions of the matrix.
          type(Hankel) :: A
          !! Corresponding hankel matrix.
       end function construct
-   end interface
-
-   interface Toeplitz
-      !! Utility function to transform an m x n `Hankel` matrix into an
-      !! m x n `Toeplitz` matrix.
-      pure module function Hankel2Toeplitz(H) result(T)
-         type(Hankel), intent(in) :: H
-         type(Toeplitz) :: T
-      end function Hankel2Toeplitz
    end interface
 
    !-------------------------------------------------------------------

--- a/src/Hankel/utils.f90
+++ b/src/Hankel/utils.f90
@@ -5,7 +5,7 @@ contains
    integer(ilp) :: i, j, m, n
    m = A%m; n = A%n; allocate (B(m, n), source=0.0_dp)
    do concurrent(j=1:n)
-      B(:, j) = A%v(j:j + m)
+      B(:, j) = A%v(j:j + m - 1)
    end do
    end procedure dense_rdp
 

--- a/src/Hankel/utils.f90
+++ b/src/Hankel/utils.f90
@@ -2,52 +2,41 @@ submodule(specialmatrices_hankel) hankel_utilities
    implicit none(type, external)
 contains
    module procedure dense_rdp
-      integer(ilp) :: i, j, m, n
-      real(dp), allocatable :: t(:)
-      m = A%m ; n = A%n ; allocate(t(-(n-1):m-1)) ; allocate(B(m, n))
-      t(:-1) = A%vr(n:2:-1)
-      t(0:) = A%vc
-      do concurrent(i=1:m, j=1:n)
-         B(i, j) = t(i-j)
-      enddo
+   integer(ilp) :: i, j, m, n
+   m = A%m; n = A%n; allocate (B(m, n), source=0.0_dp)
+   do concurrent(j=1:n)
+      B(:, j) = A%v(j:j + m)
+   end do
    end procedure dense_rdp
 
    module procedure transpose_rdp
-      B = Hankel(A%vr, A%vc)
+   B = Hankel(A%v, A%n, A%m)
    end procedure transpose_rdp
 
    module procedure size_rdp
-      if (present(dim)) then
-         select case(dim)
-            case (1)
-               arr_size = A%m
-            case (2)
-               arr_size = A%n
-            case default
-               error stop "Matrix has only two dimensions."
-         end select
-      else
-         arr_size = A%m * A%n
-      endif
+   if (present(dim)) then
+      select case (dim)
+      case (1)
+         arr_size = A%m
+      case (2)
+         arr_size = A%n
+      case default
+         error stop "Matrix has only two dimensions."
+      end select
+   else
+      arr_size = A%m*A%n
+   end if
    end procedure size_rdp
 
    module procedure shape_rdp
-      arr_shape = [A%m, A%n]
+   arr_shape = [A%m, A%n]
    end procedure shape_rdp
 
    module procedure scalar_multiplication_rdp
-      B = Hankel(alpha*A%vc, alpha*A%vr)
+   B = Hankel(alpha*A%v, A%m, A%n)
    end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
-      B = Hankel(alpha*A%vc, alpha*A%vr)
+   B = Hankel(alpha*A%v, A%m, A%n)
    end procedure scalar_multiplication_bis_rdp
-
-   module procedure Hankel2Toeplitz
-      integer(ilp) :: m, n
-      real(dp), allocatable :: vc(:), vr(:)
-      m = H%m ; n = H%n
-      vc = H%vr(2:2+m) ; vr = H%vc  ! Incorrect
-      T = Toeplitz(vc, vr)
-   end procedure Hankel2Toeplitz
 end submodule hankel_utilities

--- a/src/Hankel/utils.f90
+++ b/src/Hankel/utils.f90
@@ -1,4 +1,4 @@
-submodule(specialmatrices_toeplitz) toeplitz_utilities
+submodule(specialmatrices_hankel) hankel_utilities
    implicit none(type, external)
 contains
    module procedure dense_rdp
@@ -13,7 +13,7 @@ contains
    end procedure dense_rdp
 
    module procedure transpose_rdp
-      B = Toeplitz(A%vr, A%vc)
+      B = Hankel(A%vr, A%vc)
    end procedure transpose_rdp
 
    module procedure size_rdp
@@ -36,18 +36,18 @@ contains
    end procedure shape_rdp
 
    module procedure scalar_multiplication_rdp
-      B = Toeplitz(alpha*A%vc, alpha*A%vr)
+      B = Hankel(alpha*A%vc, alpha*A%vr)
    end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
-      B = Toeplitz(alpha*A%vc, alpha*A%vr)
+      B = Hankel(alpha*A%vc, alpha*A%vr)
    end procedure scalar_multiplication_bis_rdp
 
-   module procedure Toeplitz2Circulant
-      real(dp), allocatable :: c_vec(:)
+   module procedure Hankel2Toeplitz
       integer(ilp) :: m, n
-      m = T%m ; n = T%n ; allocate(c_vec(m+n))
-      c_vec(:m) = T%vc ; c_vec(m+1:) = cshift(T%vr(n:1:-1), -1)
-      C = Circulant(c_vec)
-   end procedure Toeplitz2Circulant
-end submodule toeplitz_utilities
+      real(dp), allocatable :: vc(:), vr(:)
+      m = H%m ; n = H%n
+      vc = H%vr(2:2+m) ; vr = H%vc  ! Incorrect
+      T = Toeplitz(vc, vr)
+   end procedure Hankel2Toeplitz
+end submodule hankel_utilities

--- a/src/Poisson2D/constructors.f90
+++ b/src/Poisson2D/constructors.f90
@@ -6,7 +6,7 @@ contains
    ! Grid spacing.
    real(dp) :: dx, dy
    A%nx = nx; A%ny = ny
-   dx = optval(Lx, 1.0_dp)/(nx+1); dy = optval(Ly, 1.0_dp)/(ny+1)
+   dx = optval(Lx, 1.0_dp)/(nx + 1); dy = optval(Ly, 1.0_dp)/(ny + 1)
    A%dx = dx; A%dy = dy
    end procedure initialize
 end submodule poisson2D_constructors

--- a/src/Poisson2D/constructors.f90
+++ b/src/Poisson2D/constructors.f90
@@ -5,8 +5,8 @@ contains
    module procedure initialize
    ! Grid spacing.
    real(dp) :: dx, dy
-   A%nx = nx; A%ny = ny;
+   A%nx = nx; A%ny = ny
    dx = optval(Lx, 1.0_dp)/(nx+1); dy = optval(Ly, 1.0_dp)/(ny+1)
    A%dx = dx; A%dy = dy
-   end procedure
-end submodule
+   end procedure initialize
+end submodule poisson2D_constructors

--- a/src/Poisson2D/eigh.f90
+++ b/src/Poisson2D/eigh.f90
@@ -21,7 +21,7 @@ contains
 
       !> Sort eigenvalues.
       call sort(lambda)
-   end procedure
+   end procedure eigvalsh_rdp
 
    module procedure eigh_rdp
       integer(ilp) :: i, j, index(A%nx*A%ny)
@@ -56,5 +56,5 @@ contains
 
       !> Sort eigenvalues and eigenvectors.
       call sort_index(lambda, index) ; vectors = vectors(:, index)
-   end procedure
-end submodule
+   end procedure eigh_rdp
+end submodule poisson2D_eigh

--- a/src/Poisson2D/eigh.f90
+++ b/src/Poisson2D/eigh.f90
@@ -5,56 +5,56 @@ submodule(specialmatrices_poisson2D) poisson2D_eigh
    implicit none(type, external)
 contains
    module procedure eigvalsh_rdp
-      integer(ilp) :: i, j
-      real(dp), pointer :: lambda_mat(:, :)
+   integer(ilp) :: i, j
+   real(dp), pointer :: lambda_mat(:, :)
 
-      !> Eigenvalues for Dx and Dy.
-      real(dp), allocatable :: lambda_x(:), lambda_y(:)
-      lambda_x = -eigvalsh(Strang(A%nx)) / A%dx**2
-      lambda_y = -eigvalsh(Strang(A%ny)) / A%dy**2
+   !> Eigenvalues for Dx and Dy.
+   real(dp), allocatable :: lambda_x(:), lambda_y(:)
+   lambda_x = -eigvalsh(Strang(A%nx))/A%dx**2
+   lambda_y = -eigvalsh(Strang(A%ny))/A%dy**2
 
-      !> Eigenvalues of the 2D Poisson operator.
-      allocate(lambda(A%nx*A%ny)) ; lambda_mat(1:A%nx, 1:A%ny) => lambda
-      do concurrent(i=1:A%nx, j=1:A%ny)
-         lambda_mat(i, j) = lambda_x(i) + lambda_y(j)
-      enddo
+   !> Eigenvalues of the 2D Poisson operator.
+   allocate (lambda(A%nx*A%ny)); lambda_mat(1:A%nx, 1:A%ny) => lambda
+   do concurrent(i=1:A%nx, j=1:A%ny)
+      lambda_mat(i, j) = lambda_x(i) + lambda_y(j)
+   end do
 
-      !> Sort eigenvalues.
-      call sort(lambda)
+   !> Sort eigenvalues.
+   call sort(lambda)
    end procedure eigvalsh_rdp
 
    module procedure eigh_rdp
-      integer(ilp) :: i, j, index(A%nx*A%ny)
-      integer(ilp) :: nx, ny, n, counter
-      real(dp), pointer :: lambda_mat(:, :)
-      real(dp), allocatable :: lambda_x(:), lambda_y(:)
-      real(dp), allocatable :: vecs_x(:, :), vecs_y(:, :)
+   integer(ilp) :: i, j, index(A%nx*A%ny)
+   integer(ilp) :: nx, ny, n, counter
+   real(dp), pointer :: lambda_mat(:, :)
+   real(dp), allocatable :: lambda_x(:), lambda_y(:)
+   real(dp), allocatable :: vecs_x(:, :), vecs_y(:, :)
 
-      nx = A%nx ; ny = A%ny ; n = nx*ny
+   nx = A%nx; ny = A%ny; n = nx*ny
 
-      !> Eigenvalues and eigevectors for Dx and Dy.
-      call eigh(Strang(A%nx), lambda_x, vecs_x)
-      call eigh(Strang(A%ny), lambda_y, vecs_y)
-      !> Scale eigenvalues.
-      lambda_x = -lambda_x / A%dx**2
-      lambda_y = -lambda_y / A%dy**2
+   !> Eigenvalues and eigevectors for Dx and Dy.
+   call eigh(Strang(A%nx), lambda_x, vecs_x)
+   call eigh(Strang(A%ny), lambda_y, vecs_y)
+   !> Scale eigenvalues.
+   lambda_x = -lambda_x/A%dx**2
+   lambda_y = -lambda_y/A%dy**2
 
-      !> Eigenvalues of the 2D Poisson operator.
-      allocate(lambda(n)) ; lambda_mat(1:nx, 1:ny) => lambda
-      do concurrent(i=1:nx, j=1:ny)
-         lambda_mat(i, j) = lambda_x(i) + lambda_y(j)
-      enddo
+   !> Eigenvalues of the 2D Poisson operator.
+   allocate (lambda(n)); lambda_mat(1:nx, 1:ny) => lambda
+   do concurrent(i=1:nx, j=1:ny)
+      lambda_mat(i, j) = lambda_x(i) + lambda_y(j)
+   end do
 
-      !> Eigenvectors of the 2D Poisson operator.
-      allocate(vectors(n, n)) ; vectors = 0.0_dp ; counter = 1
-      do j = 1, ny
-         do i = 1, nx
-            vectors(:, counter) = pack(outer_product(vecs_x(:, i), vecs_y(:, j)), .true.)
-            counter = counter + 1
-         enddo
-      enddo
+   !> Eigenvectors of the 2D Poisson operator.
+   allocate (vectors(n, n)); vectors = 0.0_dp; counter = 1
+   do j = 1, ny
+      do i = 1, nx
+         vectors(:, counter) = pack(outer_product(vecs_x(:, i), vecs_y(:, j)), .true.)
+         counter = counter + 1
+      end do
+   end do
 
-      !> Sort eigenvalues and eigenvectors.
-      call sort_index(lambda, index) ; vectors = vectors(:, index)
+   !> Sort eigenvalues and eigenvectors.
+   call sort_index(lambda, index); vectors = vectors(:, index)
    end procedure eigh_rdp
 end submodule poisson2D_eigh

--- a/src/Poisson2D/matvecs.f90
+++ b/src/Poisson2D/matvecs.f90
@@ -20,7 +20,7 @@ contains
       else
          d2x = (xmat(i-1, j) -2*xmat(i, j) + xmat(i+1, j))/dx**2
       endif
-   
+
       ! Vertical contribution.
       if (j == 1) then
          d2y = (-2*xmat(i, j) + xmat(i, j+1))/dy**2
@@ -32,8 +32,8 @@ contains
 
       ! Laplacien.
       ymat(i, j) = d2x + d2y
-   enddo 
-   end procedure
+   enddo
+   end procedure spmv
 
    module procedure spmvs
    real(dp), pointer, contiguous :: ymat(:, :, :), xmat(:, :, :)
@@ -54,7 +54,7 @@ contains
       else
          d2x = (xmat(i-1, j, k) -2*xmat(i, j, k) + xmat(i+1, j, k))/dx**2
       endif
-   
+
       ! Vertical contribution.
       if (j == 1) then
          d2y = (-2*xmat(i, j, k) + xmat(i, j+1, k))/dy**2
@@ -67,5 +67,5 @@ contains
       ! Laplacien.
       ymat(i, j, k) = d2x + d2y
    enddo
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule poisson2D_matvecs

--- a/src/Poisson2D/matvecs.f90
+++ b/src/Poisson2D/matvecs.f90
@@ -11,28 +11,28 @@ contains
    y = x; ymat(1:nx, 1:ny) => y; xmat(1:nx, 1:ny) => x
 
    ! Evaluate the Laplace operator.
-   do concurrent (i=1:nx, j=1:ny)
+   do concurrent(i=1:nx, j=1:ny)
       ! Horizontl contribution.
       if (i == 1) then
-         d2x = (-2*xmat(i, j) + xmat(i+1, j))/dx**2
+         d2x = (-2*xmat(i, j) + xmat(i + 1, j))/dx**2
       else if (i == nx) then
-         d2x = (xmat(i-1, j) - 2*xmat(i, j))/dx**2
+         d2x = (xmat(i - 1, j) - 2*xmat(i, j))/dx**2
       else
-         d2x = (xmat(i-1, j) -2*xmat(i, j) + xmat(i+1, j))/dx**2
-      endif
+         d2x = (xmat(i - 1, j) - 2*xmat(i, j) + xmat(i + 1, j))/dx**2
+      end if
 
       ! Vertical contribution.
       if (j == 1) then
-         d2y = (-2*xmat(i, j) + xmat(i, j+1))/dy**2
+         d2y = (-2*xmat(i, j) + xmat(i, j + 1))/dy**2
       else if (j == ny) then
-         d2y = (xmat(i, j-1) - 2*xmat(i, j))/dy**2
+         d2y = (xmat(i, j - 1) - 2*xmat(i, j))/dy**2
       else
-         d2y = (xmat(i, j-1) - 2*xmat(i, j) + xmat(i, j+1))/dy**2
-      endif
+         d2y = (xmat(i, j - 1) - 2*xmat(i, j) + xmat(i, j + 1))/dy**2
+      end if
 
       ! Laplacien.
       ymat(i, j) = d2x + d2y
-   enddo
+   end do
    end procedure spmv
 
    module procedure spmvs
@@ -45,27 +45,27 @@ contains
    y = x; ymat(1:nx, 1:ny, 1:nrhs) => y; xmat(1:nx, 1:ny, 1:nrhs) => x
 
    ! Evaluate the Laplace operator.
-   do concurrent (i=1:nx, j=1:ny, k=1:nrhs)
+   do concurrent(i=1:nx, j=1:ny, k=1:nrhs)
       ! Horizontl contribution.
       if (i == 1) then
-         d2x = (-2*xmat(i, j, k) + xmat(i+1, j, k))/dx**2
+         d2x = (-2*xmat(i, j, k) + xmat(i + 1, j, k))/dx**2
       else if (i == nx) then
-         d2x = (xmat(i-1, j, k) - 2*xmat(i, j, k))/dx**2
+         d2x = (xmat(i - 1, j, k) - 2*xmat(i, j, k))/dx**2
       else
-         d2x = (xmat(i-1, j, k) -2*xmat(i, j, k) + xmat(i+1, j, k))/dx**2
-      endif
+         d2x = (xmat(i - 1, j, k) - 2*xmat(i, j, k) + xmat(i + 1, j, k))/dx**2
+      end if
 
       ! Vertical contribution.
       if (j == 1) then
-         d2y = (-2*xmat(i, j, k) + xmat(i, j+1, k))/dy**2
+         d2y = (-2*xmat(i, j, k) + xmat(i, j + 1, k))/dy**2
       else if (j == ny) then
-         d2y = (xmat(i, j-1, k) - 2*xmat(i, j, k))/dy**2
+         d2y = (xmat(i, j - 1, k) - 2*xmat(i, j, k))/dy**2
       else
-         d2y = (xmat(i, j-1, k) - 2*xmat(i, j, k) + xmat(i, j+1, k))/dy**2
-      endif
+         d2y = (xmat(i, j - 1, k) - 2*xmat(i, j, k) + xmat(i, j + 1, k))/dy**2
+      end if
 
       ! Laplacien.
       ymat(i, j, k) = d2x + d2y
-   enddo
+   end do
    end procedure spmvs
 end submodule poisson2D_matvecs

--- a/src/Poisson2D/solve.f90
+++ b/src/Poisson2D/solve.f90
@@ -47,7 +47,7 @@ contains
          call dst(ny, xmat(i, :), wsave_y)
       enddo
       xmat = scale * xmat
-  end procedure
+  end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
       integer(ilp) :: i
@@ -55,6 +55,6 @@ contains
       do concurrent(i=1:size(b, 2))
          x(:, i) = solve(A, b(:, i))
       enddo
-   end procedure
+   end procedure solve_multi_rhs
 
-end submodule
+end submodule poisson2D_solve

--- a/src/Poisson2D/solve.f90
+++ b/src/Poisson2D/solve.f90
@@ -5,56 +5,56 @@ submodule(specialmatrices_poisson2D) poisson2D_solve
    character(len=*), parameter :: this = "poisson2D_linear_solver"
 contains
    module procedure solve_single_rhs
-      ! Local variables.
-      integer(ilp) :: nx, ny, i, j, nx_wrk, ny_wrk
-      real(dp), allocatable :: lambda_x(:), lambda_y(:)
-      real(dp), allocatable :: wsave_x(:), wsave_y(:)
-      real(dp), pointer     :: xmat(:, :)
-      real(dp) :: scale
+   ! Local variables.
+   integer(ilp) :: nx, ny, i, j, nx_wrk, ny_wrk
+   real(dp), allocatable :: lambda_x(:), lambda_y(:)
+   real(dp), allocatable :: wsave_x(:), wsave_y(:)
+   real(dp), pointer     :: xmat(:, :)
+   real(dp) :: scale
 
-      ! Initializes pointer and allocatable arrays.
-      nx = A%nx ; ny = A%ny
-      x = b ; xmat(1:nx, 1:ny) => x
-      nx_wrk = int(2.5*nx + 15, kind=ilp) ; ny_wrk = int(2.5*ny + 15, kind=ilp)
-      allocate(wsave_x(nx_wrk)) ; allocate(wsave_y(ny_wrk))
+   ! Initializes pointer and allocatable arrays.
+   nx = A%nx; ny = A%ny
+   x = b; xmat(1:nx, 1:ny) => x
+   nx_wrk = int(2.5*nx + 15, kind=ilp); ny_wrk = int(2.5*ny + 15, kind=ilp)
+   allocate (wsave_x(nx_wrk)); allocate (wsave_y(ny_wrk))
 
-      ! Initializes Discrete Sine Transforms (Type-I).
-      call init_dst(nx, wsave_x) ; call init_dst(ny, wsave_y)
+   ! Initializes Discrete Sine Transforms (Type-I).
+   call init_dst(nx, wsave_x); call init_dst(ny, wsave_y)
 
-      ! Compute the DST-I of the right-hand side.
-      do concurrent(j=1:ny)
-         call dst(nx, xmat(:, j), wsave_x)
-      enddo
-      do concurrent(i=1:nx)
-         call dst(ny, xmat(i, :), wsave_y)
-      enddo
+   ! Compute the DST-I of the right-hand side.
+   do concurrent(j=1:ny)
+      call dst(nx, xmat(:, j), wsave_x)
+   end do
+   do concurrent(i=1:nx)
+      call dst(ny, xmat(i, :), wsave_y)
+   end do
 
-      ! Compute the eigenvalues of the 1D Laplacian operators.
-      lambda_x = -eigvalsh(Strang(nx)) / A%dx**2
-      lambda_y = -eigvalsh(Strang(ny)) / A%dy**2
+   ! Compute the eigenvalues of the 1D Laplacian operators.
+   lambda_x = -eigvalsh(Strang(nx))/A%dx**2
+   lambda_y = -eigvalsh(Strang(ny))/A%dy**2
 
-      ! Compute the solution in spectral space.
-      do concurrent(i=1:nx, j=1:ny)
-         xmat(i, j) = xmat(i, j) / (lambda_x(i) + lambda_y(j))
-      enddo
+   ! Compute the solution in spectral space.
+   do concurrent(i=1:nx, j=1:ny)
+      xmat(i, j) = xmat(i, j)/(lambda_x(i) + lambda_y(j))
+   end do
 
-      ! Inverse DST-I of the solution.
-      scale = 1.0_dp / (2*(nx+1) * 2*(ny+1))
-      do concurrent(j=1:ny)
-         call dst(nx, xmat(:, j), wsave_x)
-      enddo
-      do concurrent(i=1:nx)
-         call dst(ny, xmat(i, :), wsave_y)
-      enddo
-      xmat = scale * xmat
-  end procedure solve_single_rhs
+   ! Inverse DST-I of the solution.
+   scale = 1.0_dp/(2*(nx + 1)*2*(ny + 1))
+   do concurrent(j=1:ny)
+      call dst(nx, xmat(:, j), wsave_x)
+   end do
+   do concurrent(i=1:nx)
+      call dst(ny, xmat(i, :), wsave_y)
+   end do
+   xmat = scale*xmat
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
-      integer(ilp) :: i
-      allocate(x, mold=b)
-      do concurrent(i=1:size(b, 2))
-         x(:, i) = solve(A, b(:, i))
-      enddo
+   integer(ilp) :: i
+   allocate (x, mold=b)
+   do concurrent(i=1:size(b, 2))
+      x(:, i) = solve(A, b(:, i))
+   end do
    end procedure solve_multi_rhs
 
 end submodule poisson2D_solve

--- a/src/Poisson2D/specialmatrices_poisson2D.f90
+++ b/src/Poisson2D/specialmatrices_poisson2D.f90
@@ -29,7 +29,7 @@ module specialmatrices_poisson2D
       !! Dimension of the grid in each direction.
       real(dp) :: dx, dy
       !! Grid spacing in each direction.
-   end type
+   end type Poisson2D
 
    !--------------------------------
    !-----     Constructors     -----
@@ -58,7 +58,7 @@ module specialmatrices_poisson2D
       !! @note
       !! Only `doube precision` is currently supported for this matrix type.
       !! @endnote
-      !! 
+      !!
       !! @note
       !! Note that `Lx` and `Ly` are optional. If not specified, they default
       !! to `1.0_dp`.
@@ -71,7 +71,7 @@ module specialmatrices_poisson2D
          !! Physical extent of each dimension.
          type(Poisson2D) :: A
          !! Corresponding Poisson2D matrix.
-      end function
+      end function initialize
    end interface
 
    !-------------------------------------------------------------------
@@ -99,7 +99,7 @@ module specialmatrices_poisson2D
          !! Input vector.
          real(dp), allocatable, target :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y=AX\) for a `Poisson2D` matrix \( A \).
@@ -110,7 +110,7 @@ module specialmatrices_poisson2D
          !! Input vectors.
          real(dp), allocatable, target :: y(:, :)
          !! Output vectors.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -155,7 +155,7 @@ module specialmatrices_poisson2D
          !! Right-hand side vector.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, b) result(x)
          !! Solve the linear system \(AX=B\) using a fast Poisson solver.
@@ -165,7 +165,7 @@ module specialmatrices_poisson2D
          !! Right-hand side vectors.
          real(dp), allocatable, target :: x(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    !--------------------------------------------
@@ -198,7 +198,7 @@ module specialmatrices_poisson2D
          !! Input matrix.
          real(dp), allocatable, target :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvalsh_rdp
    end interface
 
    interface eigh
@@ -232,7 +232,7 @@ module specialmatrices_poisson2D
          real(dp), allocatable, intent(out), target :: lambda(:)
          !! Eigenvalues.
          real(dp), allocatable, intent(out) :: vectors(:, :)
-      end subroutine
+      end subroutine eigh_rdp
    end interface
 
    !-------------------------------------
@@ -260,7 +260,7 @@ module specialmatrices_poisson2D
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
          !! Dense representation.
-      end function
+      end function dense_rdp
    end interface
 
    interface shape
@@ -271,7 +271,7 @@ module specialmatrices_poisson2D
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface size
@@ -285,8 +285,8 @@ module specialmatrices_poisson2D
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Corresponding size.
-      end function
+      end function size_rdp
    end interface
 
 contains
-end module
+end module specialmatrices_poisson2D

--- a/src/Poisson2D/specialmatrices_poisson2D.f90
+++ b/src/Poisson2D/specialmatrices_poisson2D.f90
@@ -15,7 +15,6 @@ module specialmatrices_poisson2D
    public :: shape
    public :: size
 
-
    !------------------------------------------------------
    !-----     Base type for the Poisson2D matrix     -----
    !------------------------------------------------------
@@ -65,6 +64,7 @@ module specialmatrices_poisson2D
       !! @endnote
       pure module function initialize(nx, ny, Lx, Ly) result(A)
          !! Utility function to construct a `Poisson2D` matrix.
+         implicit none(type, external)
          integer(ilp), intent(in) :: nx, ny
          !! Number of grid points in each direction.
          real(dp), optional, intent(in) :: Lx, Ly
@@ -93,6 +93,7 @@ module specialmatrices_poisson2D
       module function spmv(A, x) result(y)
          !! Compute the matrix-vector product \(y = Ax\) for a `Poisson2D` matrix \( A \).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          real(dp), target, intent(in) :: x(:)
@@ -104,6 +105,7 @@ module specialmatrices_poisson2D
       module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y=AX\) for a `Poisson2D` matrix \( A \).
          !! \(X\) and \(Y\) are rank-2 arrays of appropriate size with the same kind as \(A\).
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          real(dp), target, contiguous, intent(in) :: x(:, :)
@@ -149,6 +151,7 @@ module specialmatrices_poisson2D
       !! @endnote
       pure module function solve_single_rhs(A, b) result(x)
          !! Solve the linear system \(Ax = b\) using a fast Poisson solver.
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -159,6 +162,7 @@ module specialmatrices_poisson2D
 
       pure module function solve_multi_rhs(A, b) result(x)
          !! Solve the linear system \(AX=B\) using a fast Poisson solver.
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
@@ -194,6 +198,7 @@ module specialmatrices_poisson2D
       !! and can thus be computed efficiently.
       !! @endnote
       module function eigvalsh_rdp(A) result(lambda)
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, target :: lambda(:)
@@ -227,6 +232,7 @@ module specialmatrices_poisson2D
       !! known analytically and can thus be constructed efficiently.
       !! @endnote
       module subroutine eigh_rdp(A, lambda, vectors)
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out), target :: lambda(:)
@@ -256,6 +262,7 @@ module specialmatrices_poisson2D
       !! - `B` :  Rank-2 `real` array corresponding to the dense representation
       !!          of `A`.
       pure module function dense_rdp(A) result(B)
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
@@ -267,6 +274,7 @@ module specialmatrices_poisson2D
       !! Utility function to return the shape a `Poisson2D` matrix \(A\).
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of the `Poisson2D` matrix.
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -279,6 +287,7 @@ module specialmatrices_poisson2D
       !! along a given dimension.
       pure module function size_rdp(A, dim) result(arr_size)
          !! Utility function to return the size of a `Poisson2D` matrix along a given dimension.
+         implicit none(type, external)
          type(Poisson2D), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim

--- a/src/Poisson2D/utils.f90
+++ b/src/Poisson2D/utils.f90
@@ -1,6 +1,6 @@
 submodule(specialmatrices_poisson2D) poisson2D_utils
    use stdlib_linalg, only: eye, kron => kronecker_product
-   use specialmatrices_strang
+   use specialmatrices_strang, only: strang
    implicit none(type, external)
 contains
 
@@ -21,10 +21,10 @@ contains
    end procedure dense_rdp
 
    module procedure shape_rdp
-      arr_shape = A%nx * A%ny
+   arr_shape = A%nx*A%ny
    end procedure shape_rdp
 
    module procedure size_rdp
-      arr_size = A%nx * A%ny
+   arr_size = A%nx*A%ny
    end procedure size_rdp
 end submodule poisson2D_utils

--- a/src/Poisson2D/utils.f90
+++ b/src/Poisson2D/utils.f90
@@ -18,13 +18,13 @@ contains
    ! Corresponding 2D Laplace operator.
    Idx = eye(nx, mold=1.0_dp); Idy = eye(ny, mold=1.0_dp)
    B = kron(Idy, D2x) + kron(D2y, Idx)
-   end procedure
+   end procedure dense_rdp
 
    module procedure shape_rdp
       arr_shape = A%nx * A%ny
-   end procedure
+   end procedure shape_rdp
 
    module procedure size_rdp
       arr_size = A%nx * A%ny
-   end procedure
-end submodule
+   end procedure size_rdp
+end submodule poisson2D_utils

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -7,6 +7,7 @@ module SpecialMatrices
    use specialmatrices_poisson2D
    use specialmatrices_circulant
    use specialmatrices_toeplitz
+   use specialmatrices_hankel
    implicit none
    private
 

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -23,6 +23,7 @@ module SpecialMatrices
    public :: Poisson2D
    public :: Circulant
    public :: Toeplitz
+   public :: Hankel
 
    !----------------------------------
    !-----     Linear Algebra     -----

--- a/src/SpecialMatrices.f90
+++ b/src/SpecialMatrices.f90
@@ -8,7 +8,7 @@ module SpecialMatrices
    use specialmatrices_circulant
    use specialmatrices_toeplitz
    use specialmatrices_hankel
-   implicit none
+   implicit none(type, external)
    private
 
    !--------------------------------
@@ -48,9 +48,4 @@ module SpecialMatrices
    public :: size
    public :: operator(*)
 
-   public :: say_hello
-contains
-   subroutine say_hello
-      print *, "Hello, SpecialMatrices!"
-   end subroutine say_hello
 end module SpecialMatrices

--- a/src/Strang/constructors.f90
+++ b/src/Strang/constructors.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_strang) strang_constructors
 contains
    module procedure initialize
    A%n = n
-   end procedure
-end submodule
+   end procedure initialize
+end submodule strang_constructors

--- a/src/Strang/det.f90
+++ b/src/Strang/det.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_strang) strang_determinant
 contains
    module procedure det_rdp
    d = A%n + 1
-   end procedure
-end submodule
+   end procedure det_rdp
+end submodule strang_determinant

--- a/src/Strang/eigh.f90
+++ b/src/Strang/eigh.f90
@@ -5,7 +5,7 @@ contains
    module procedure eigvalsh_rdp
    integer(ilp) :: k, n
    n = A%n; lambda = 2*[(1 - cos((pi*k)/(n + 1)), k=1, n)]
-   end procedure
+   end procedure eigvalsh_rdp
 
    module procedure eigh_rdp
    integer(ilp) :: i, j, n
@@ -15,5 +15,5 @@ contains
    do concurrent(i=1:n, j=1:n)
       vectors(i, j) = sqrt(2.0_dp/(n + 1))*sin((i*j*pi)/(n + 1))
    end do
-   end procedure
-end submodule
+   end procedure eigh_rdp
+end submodule strang_eigh

--- a/src/Strang/matvecs.f90
+++ b/src/Strang/matvecs.f90
@@ -9,7 +9,7 @@ contains
       y(i) = -x(i - 1) + 2*x(i) - x(i + 1)
    end do
    y(n) = 2*x(n) - x(n - 1)
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    integer(ilp) :: i
@@ -17,5 +17,5 @@ contains
    do concurrent(i=1:size(x, 2))
       y(:, i) = spmv(A, x(:, i))
    end do
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule strang_matvecs

--- a/src/Strang/solve.f90
+++ b/src/Strang/solve.f90
@@ -14,14 +14,14 @@ contains
    refine_ = optval(refine, .false.)
    x = b; xmat(1:A%n, 1:1) => x; bmat(1:A%n, 1:1) => b
    xmat = posdef_symtridiagonal_solver(A, bmat, refine_)
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
    ! Local variables.
    logical(lk) :: refine_
    refine_ = optval(refine, .false.)
    x = posdef_symtridiagonal_solver(A, b, refine_)
-   end procedure
+   end procedure solve_multi_rhs
 
    !-----------------------------------------------------------
    !-----     Positive-definite SymTridiagonal Solver     -----
@@ -171,5 +171,5 @@ contains
       end if
    end function posdef_symtridiagonal_solver
 
-end submodule
+end submodule strang_linear_solver
 

--- a/src/Strang/specialmatrices_strang.f90
+++ b/src/Strang/specialmatrices_strang.f90
@@ -62,6 +62,7 @@ module specialmatrices_strang
       !! @endnote
       pure module function initialize(n) result(A)
          !! Construct the Strang matrix of size `n`.
+         implicit none(type, external)
          integer(ilp), intent(in) :: n
          !! Dimension of the matrix.
          type(Strang) :: A
@@ -87,6 +88,7 @@ module specialmatrices_strang
       !! ```
       pure module function spmv(A, x) result(y)
          !! Driver for the matrix-vector product.
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:)
@@ -97,6 +99,7 @@ module specialmatrices_strang
 
       pure module function spmvs(A, X) result(Y)
          !! Driver for the matrix-matrix product.
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
@@ -132,6 +135,7 @@ module specialmatrices_strang
       !! - `x` :  Solution of the linear system. It has the same type and
       !!          shape as `b`.
       module function solve_single_rhs(A, b, refine) result(x)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Coefficient matrix.
          real(dp), target, intent(in) :: b(:)
@@ -143,6 +147,7 @@ module specialmatrices_strang
       end function solve_single_rhs
 
       module function solve_multi_rhs(A, b, refine) result(x)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
@@ -175,6 +180,7 @@ module specialmatrices_strang
       !!
       !! - `d` :  Determinant of the matrix.
       pure module function det_rdp(A) result(d)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp) :: d
@@ -198,6 +204,7 @@ module specialmatrices_strang
       !!
       !! - `tr`:  Trace of the matrix.
       pure module function trace_rdp(A) result(tr)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp) :: tr
@@ -227,6 +234,7 @@ module specialmatrices_strang
       !! - `lambda`  :  Rank-1 `real` array returning the eigenvalues of `A`
       !!                in increasing order. It is an `intent(out)` argument.
       pure module function eigvalsh_rdp(A) result(lambda)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
@@ -259,6 +267,7 @@ module specialmatrices_strang
       !! analytically and can thus be constructed very efficiently.
       !! @endnote
       pure module subroutine eigh_rdp(A, lambda, vectors)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out) :: lambda(:)
@@ -288,6 +297,7 @@ module specialmatrices_strang
       !!
       !! - `B` :  Rank-2 array representation fo the matrix \(A\).
       pure module function dense_rdp(A) result(B)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
@@ -298,6 +308,7 @@ module specialmatrices_strang
    interface shape
       !! Utility function returning the shape of a `Strang` matrix \(A\).
       pure module function shape_rdp(A) result(arr_shape)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -309,6 +320,7 @@ module specialmatrices_strang
       !! Utility function returning the size of a `Strang` matrix \(A\)
       !! along a given dimension.
       pure module function size_rdp(A, dim) result(arr_size)
+         implicit none(type, external)
          type(Strang), intent(in) :: A
          !! Input matrix.
          integer(ilp), intent(in) :: dim

--- a/src/Strang/specialmatrices_strang.f90
+++ b/src/Strang/specialmatrices_strang.f90
@@ -22,7 +22,7 @@ module specialmatrices_strang
       !! Base type used to define the `Strang` matrix.
       integer(ilp) :: n
       !! Dimension of the matrix.
-   end type
+   end type Strang
 
    !--------------------------------
    !-----     Constructors     -----
@@ -66,7 +66,7 @@ module specialmatrices_strang
          !! Dimension of the matrix.
          type(Strang) :: A
          !! Strang matrix of size `n`.
-      end function
+      end function initialize
    end interface
 
    !-------------------------------------------------------------------
@@ -93,7 +93,7 @@ module specialmatrices_strang
          !! Input vector.
          real(dp), allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Driver for the matrix-matrix product.
@@ -103,7 +103,7 @@ module specialmatrices_strang
          !! Input vector.
          real(dp), allocatable :: Y(:, :)
          !! Output vector.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -140,7 +140,7 @@ module specialmatrices_strang
          !! Whether iterative refinement is used or not.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       module function solve_multi_rhs(A, b, refine) result(x)
          type(Strang), intent(in) :: A
@@ -151,7 +151,7 @@ module specialmatrices_strang
          !! Whether iterative refinement is used or not.
          real(dp), allocatable :: x(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    !-----------------------------------------
@@ -179,7 +179,7 @@ module specialmatrices_strang
          !! Input matrix.
          real(dp) :: d
          !! Determinant of the matrix.
-      end function
+      end function det_rdp
    end interface
 
    interface trace
@@ -202,7 +202,7 @@ module specialmatrices_strang
          !! Input matrix.
          real(dp) :: tr
          !! Trace of the matrix.
-      end function
+      end function trace_rdp
    end interface
 
    !--------------------------------------------
@@ -223,7 +223,7 @@ module specialmatrices_strang
       !! #### Arguments
       !!
       !! - `A` :  Matrix of type `Strang`. It is an `intent(in)` argument.
-      !! 
+      !!
       !! - `lambda`  :  Rank-1 `real` array returning the eigenvalues of `A`
       !!                in increasing order. It is an `intent(out)` argument.
       pure module function eigvalsh_rdp(A) result(lambda)
@@ -231,7 +231,7 @@ module specialmatrices_strang
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvalsh_rdp
    end interface
 
    interface eigh
@@ -265,7 +265,7 @@ module specialmatrices_strang
          !! Eigenvalues.
          real(dp), allocatable, intent(out) :: vectors(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eigh_rdp
    end interface
 
    !-------------------------------------
@@ -292,7 +292,7 @@ module specialmatrices_strang
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
          !! Dense representation.
-      end function
+      end function dense_rdp
    end interface
 
    interface shape
@@ -302,7 +302,7 @@ module specialmatrices_strang
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface size
@@ -315,7 +315,7 @@ module specialmatrices_strang
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Corresponding size.
-      end function
+      end function size_rdp
    end interface
 contains
-end module
+end module specialmatrices_strang

--- a/src/Strang/trace.f90
+++ b/src/Strang/trace.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_strang) strange_trace
 contains
    module procedure trace_rdp
    tr = A%n*2
-   end procedure
-end submodule
+   end procedure trace_rdp
+end submodule strange_trace

--- a/src/Strang/utils.f90
+++ b/src/Strang/utils.f90
@@ -10,13 +10,13 @@ contains
       B(i, i - 1) = -1; B(i, i) = 2; B(i, i + 1) = -1
    end do
    B(n, n - 1) = -1; B(n, n) = 2
-   end procedure
+   end procedure dense_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
-end submodule
+   end procedure size_rdp
+end submodule strang_utils

--- a/src/SymTridiagonal/constructors.f90
+++ b/src/SymTridiagonal/constructors.f90
@@ -6,17 +6,17 @@ contains
    module procedure initialize
    A%n = n; allocate (A%dv(n)); allocate (A%ev(n - 1))
    A%dv = 0.0_dp; A%ev = 0.0_dp; A%isposdef = .false.
-   end procedure
+   end procedure initialize
 
    module procedure construct
    integer(ilp) :: n
    n = size(dv)
    A%n = n; A%dv = dv; A%ev = ev; A%isposdef = optval(isposdef, .false.)
-   end procedure
+   end procedure construct
 
    module procedure construct_constant
    integer(ilp) :: i
    A%n = n; A%isposdef = optval(isposdef, .false.)
    A%dv = [(d, i=1, n)]; A%ev = [(e, i=1, n - 1)]
-   end procedure
-end submodule
+   end procedure construct_constant
+end submodule symtridiagonal_constructors

--- a/src/SymTridiagonal/det.f90
+++ b/src/SymTridiagonal/det.f90
@@ -14,5 +14,5 @@ contains
       ! Store previous values.
       f_1 = f_0; f_0 = d
    end do
-   end procedure
-end submodule
+   end procedure det_rdp
+end submodule symtridiagonal_determinant

--- a/src/SymTridiagonal/eigh.f90
+++ b/src/SymTridiagonal/eigh.f90
@@ -75,10 +75,10 @@ contains
 
    ! Return results.
    lambda = dv
-   end procedure
+   end procedure eigh_rdp
 
    module procedure eigvalsh_rdp
    call eigh(A, lambda)
-   end procedure
+   end procedure eigvalsh_rdp
 
 end submodule symtridiagonal_eigenvalue_decomposition

--- a/src/SymTridiagonal/matvecs.f90
+++ b/src/SymTridiagonal/matvecs.f90
@@ -15,7 +15,7 @@ contains
    ! Matrix-vector product.
    call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, A%ev, xmat, ldx, beta, ymat, ldy)
 
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    ! Local variables.
@@ -28,5 +28,5 @@ contains
    ! Matrix-vector product.
    call lagtm(trans, n, nrhs, alpha, A%ev, A%dv, A%ev, x, ldx, beta, y, ldy)
 
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule symtridiagonal_matvecs

--- a/src/SymTridiagonal/solve.f90
+++ b/src/SymTridiagonal/solve.f90
@@ -20,7 +20,7 @@ contains
    else
       xmat = symtridiagonal_solver(A, bmat, refine_)
    end if
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
    ! Local variables.
@@ -31,7 +31,7 @@ contains
    else
       x = symtridiagonal_solver(A, b, refine_)
    end if
-   end procedure
+   end procedure solve_multi_rhs
 
    !---------------------------------------------------
    !-----     Generic (Sym)Tridiagonal Solver     -----
@@ -182,7 +182,7 @@ contains
 
       ! ----- Allocations -----
       allocate (du2(n - 2), ipiv(n))
-      dl = A%ev; d = A%dv; du = A%ev; 
+      dl = A%ev; d = A%dv; du = A%ev
       ! ----- LU factorization -----
       call gttrf(n, dl, d, du, du2, ipiv, info)
       call handle_gttrf_info(n, info, err)
@@ -355,4 +355,4 @@ contains
       end if
    end function posdef_symtridiagonal_solver
 
-end submodule
+end submodule symtridiagonal_linear_solver

--- a/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
+++ b/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
@@ -32,7 +32,7 @@ module specialmatrices_symtridiagonal
       real(dp), allocatable :: dv(:), ev(:)
       !! SymTridiagonal elements of the matrix.
       logical(lk) :: isposdef
-   end type
+   end type SymTridiagonal
 
    !--------------------------------
    !-----     Constructors     -----
@@ -103,7 +103,7 @@ module specialmatrices_symtridiagonal
          !! Dimension of the matrix.
          type(SymTridiagonal) :: A
          !! Symmetric Tridiagonal matrix.
-      end function
+      end function initialize
 
       pure module function construct(dv, ev, isposdef) result(A)
          !! Construct a `SymTridiagonal` matrix from the rank-1 arrays
@@ -114,7 +114,7 @@ module specialmatrices_symtridiagonal
          !! Whether `A` is positive-definite or not.
          type(SymTridiagonal) :: A
          !! Symmetric Tridiagonal matrix.
-      end function
+      end function construct
 
       pure module function construct_constant(d, e, n, isposdef) result(A)
          !! Construct a `SymTridiagonal` matrix with constant diagonal
@@ -127,7 +127,7 @@ module specialmatrices_symtridiagonal
          !! Whether `A` is positive-definite or not.
          type(SymTridiagonal) :: A
          !! Symmetric Tridiagonal matrix.
-      end function
+      end function construct_constant
    end interface
 
    !-------------------------------------------------------------------
@@ -157,7 +157,7 @@ module specialmatrices_symtridiagonal
          !! Input vector.
          real(dp), target, allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y = Ax\) for a `SymTridiagonal`
@@ -169,7 +169,7 @@ module specialmatrices_symtridiagonal
          !! Input vectors.
          real(dp), allocatable :: Y(:, :)
          !! Output vectors.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -212,7 +212,7 @@ module specialmatrices_symtridiagonal
          !! Whether iterative refinement of the solution is used or not.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       module function solve_multi_rhs(A, b, refine) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type
@@ -226,7 +226,7 @@ module specialmatrices_symtridiagonal
          !! Whether iterative refinement of the solution is used or not.
          real(dp), allocatable :: x(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    interface inv
@@ -236,7 +236,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
          !! Inverse of `A`.
-      end function
+      end function inv_rdp
    end interface
 
    !-----------------------------------------
@@ -266,7 +266,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          real(dp) :: d
          !! Determinant of the matrix.
-      end function
+      end function det_rdp
    end interface
 
    interface trace
@@ -291,7 +291,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          real(dp) :: tr
          !! Trace of the matrix.
-      end function
+      end function trace_rdp
    end interface
 
    !------------------------------------------------
@@ -320,7 +320,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -362,7 +362,7 @@ module specialmatrices_symtridiagonal
          !! Left singular vectors as columns.
          real(dp), allocatable, optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -393,7 +393,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvalsh_rdp
    end interface
 
    interface eigh
@@ -427,7 +427,7 @@ module specialmatrices_symtridiagonal
          !! Eigenvalues.
          real(dp), allocatable, optional, target, intent(out) :: vectors(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eigh_rdp
    end interface
 
    !-------------------------------------
@@ -456,7 +456,7 @@ module specialmatrices_symtridiagonal
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -481,7 +481,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          type(SymTridiagonal) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -494,7 +494,7 @@ module specialmatrices_symtridiagonal
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -504,7 +504,7 @@ module specialmatrices_symtridiagonal
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -523,4 +523,4 @@ module specialmatrices_symtridiagonal
       end function scalar_multiplication_bis_rdp
    end interface
 
-end module
+end module specialmatrices_symtridiagonal

--- a/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
+++ b/src/SymTridiagonal/specialmatrices_symtridiagonal.f90
@@ -99,6 +99,7 @@ module specialmatrices_symtridiagonal
       !! @endnote
       pure module function initialize(n) result(A)
          !! Construct a `SymTridiagonal` matrix filled with zeros.
+         implicit none(type, external)
          integer(ilp), intent(in) :: n
          !! Dimension of the matrix.
          type(SymTridiagonal) :: A
@@ -108,6 +109,7 @@ module specialmatrices_symtridiagonal
       pure module function construct(dv, ev, isposdef) result(A)
          !! Construct a `SymTridiagonal` matrix from the rank-1 arrays
          !! `dv` and `ev`.
+         implicit none(type, external)
          real(dp), intent(in) :: dv(:), ev(:)
          !! SymTridiagonal elements of the matrix.
          logical(lk), optional, intent(in) :: isposdef
@@ -119,6 +121,7 @@ module specialmatrices_symtridiagonal
       pure module function construct_constant(d, e, n, isposdef) result(A)
          !! Construct a `SymTridiagonal` matrix with constant diagonal
          !! elements.
+         implicit none(type, external)
          real(dp), intent(in) :: d, e
          !! SymTridiagonal elements of the matrix.
          integer(ilp), intent(in) :: n
@@ -151,6 +154,7 @@ module specialmatrices_symtridiagonal
          !! Compute the matrix-vector product \(y = Ax\) for a `SymTridiagonal`
          !! matrix \(A\). Both `x` and `y` are rank-1 arrays with the same
          !! kind as `A`.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), target, intent(in) :: x(:)
@@ -163,6 +167,7 @@ module specialmatrices_symtridiagonal
          !! Compute the matrix-matrix product \(Y = Ax\) for a `SymTridiagonal`
          !! matrix \(A\) and a dense matrix \(X\) (rank-2 array). \(Y\) is
          !! also a rank-2 array with the same dimensions as \(X\).
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
@@ -204,6 +209,7 @@ module specialmatrices_symtridiagonal
          !! Solve the linear system \(Ax=b\) where \(A\) is of type
          !! `SymTridiagonal` and `b` a standard rank-1 array. The solution
          !! vector `x` has the same dimension and kind as `b`.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), target, intent(in) :: b(:)
@@ -218,6 +224,7 @@ module specialmatrices_symtridiagonal
          !! Solve the linear system \(AX=B\) where \(A\) is of type
          !! `SymTridiagonal` and `B` a standard rank-2 array. The solution
          !! matrix `X` has the same dimensions and kind as `B`.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
@@ -232,6 +239,7 @@ module specialmatrices_symtridiagonal
    interface inv
       pure module function inv_rdp(A) result(B)
          !! Compute the inverse of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
@@ -262,6 +270,7 @@ module specialmatrices_symtridiagonal
       !! - `d` :  Determinant of the matrix.
       pure module function det_rdp(A) result(d)
          !! Compute the determinant of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: d
@@ -287,6 +296,7 @@ module specialmatrices_symtridiagonal
       !! - `tr`:  Trace of the matrix.
       pure module function trace_rdp(A) result(tr)
          !! Compute the trace of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: tr
@@ -316,6 +326,7 @@ module specialmatrices_symtridiagonal
       !! - `s` :  Vector of singular values sorted in decreasing order.
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -354,6 +365,7 @@ module specialmatrices_symtridiagonal
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `SymTridiagonal`
          !! matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out) :: s(:)
@@ -389,6 +401,7 @@ module specialmatrices_symtridiagonal
       module function eigvalsh_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real
          !! `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: lambda(:)
@@ -421,6 +434,7 @@ module specialmatrices_symtridiagonal
       module subroutine eigh_rdp(A, lambda, vectors)
          !! Compute the eigenvalues and eigenvectors of a `SymTridiagonal`
          !! matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable, intent(out) :: lambda(:)
@@ -452,6 +466,7 @@ module specialmatrices_symtridiagonal
       !! - `B` :  Rank-2 array representation of the matrix \( A \).
       module function dense_rdp(A) result(B)
          !! Convert a `SymTridiagonal` matrix to a rank-2 array.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -477,6 +492,7 @@ module specialmatrices_symtridiagonal
       !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
       pure module function transpose_rdp(A) result(B)
          !! Compute the transpose of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          type(SymTridiagonal) :: B
@@ -488,6 +504,7 @@ module specialmatrices_symtridiagonal
       pure module function size_rdp(A, dim) result(arr_size)
          !! Return the size of `SymTridiagonal` matrix along a given
          !! dimension.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -500,6 +517,7 @@ module specialmatrices_symtridiagonal
    interface shape
       pure module function shape_rdp(A) result(arr_shape)
          !! Return the shape of a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -510,6 +528,7 @@ module specialmatrices_symtridiagonal
    interface operator(*)
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Scalar multiplication with a `SymTridiagonal` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(SymTridiagonal), intent(in) :: A
          type(SymTridiagonal) :: B
@@ -517,6 +536,7 @@ module specialmatrices_symtridiagonal
 
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Scalar multiplication with a `SymTridiagonal` matrix.
+         implicit none(type, external)
          type(SymTridiagonal), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(SymTridiagonal) :: B

--- a/src/SymTridiagonal/svd.f90
+++ b/src/SymTridiagonal/svd.f90
@@ -4,7 +4,7 @@ contains
    module procedure svdvals_rdp
    ! Get singular values from the eigendecomposition.
    s = abs(eigvalsh(A))
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
    integer(ilp) :: i, n
@@ -21,5 +21,5 @@ contains
    end if
    ! Singular values.
    s = abs(s)
-   end procedure
-end submodule
+   end procedure svd_rdp
+end submodule symtridiagonal_singular_value_decomposition

--- a/src/SymTridiagonal/trace.f90
+++ b/src/SymTridiagonal/trace.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_symtridiagonal) symtridiagonal_trace
 contains
    module procedure trace_rdp
    tr = sum(A%dv)
-   end procedure
-end submodule
+   end procedure trace_rdp
+end submodule symtridiagonal_trace

--- a/src/SymTridiagonal/utils.f90
+++ b/src/SymTridiagonal/utils.f90
@@ -11,28 +11,28 @@ contains
       B(i, i + 1) = A%ev(i)
    end do
    B(n, n - 1) = A%ev(n - 1); B(n, n) = A%dv(n)
-   end procedure
+   end procedure dense_rdp
 
    module procedure transpose_rdp
    B = A
-   end procedure
+   end procedure transpose_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
+   end procedure size_rdp
 
    module procedure scalar_multiplication_rdp
    B = SymTridiagonal(alpha*A%dv, alpha*A%ev)
    if (alpha <= 0.0_dp) B%isposdef = .false.
-   end procedure
+   end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
    B = SymTridiagonal(alpha*A%dv, alpha*A%ev)
    if (alpha <= 0.0_dp) B%isposdef = .false.
-   end procedure
+   end procedure scalar_multiplication_bis_rdp
 
-end submodule
+end submodule symtridiagonal_utils

--- a/src/Toeplitz/constructors.f90
+++ b/src/Toeplitz/constructors.f90
@@ -8,5 +8,5 @@ contains
    A%vc = vc ; A%vr = vr
    !> Ensure vc[1] and vr[1] are the same.
    A%vr(1) = A%vc(1)
-   end procedure
-end submodule
+   end procedure construct
+end submodule toeplitz_constructors

--- a/src/Toeplitz/constructors.f90
+++ b/src/Toeplitz/constructors.f90
@@ -3,9 +3,9 @@ submodule(specialmatrices_toeplitz) toeplitz_constructors
 contains
    module procedure construct
    !> Dimension of the matrix.
-   A%m = size(vc) ; A%n = size(vr)
+   A%m = size(vc); A%n = size(vr)
    !> First column/row vectors.
-   A%vc = vc ; A%vr = vr
+   A%vc = vc; A%vr = vr
    !> Ensure vc[1] and vr[1] are the same.
    A%vr(1) = A%vc(1)
    end procedure construct

--- a/src/Toeplitz/eig.f90
+++ b/src/Toeplitz/eig.f90
@@ -1,12 +1,12 @@
-submodule (specialmatrices_toeplitz) toeplitz_eigendecomposition
+submodule(specialmatrices_toeplitz) toeplitz_eigendecomposition
    implicit none(type, external)
 contains
    module procedure eigvals_rdp
-      lambda = eigvals(dense(A))
+   lambda = eigvals(dense(A))
    end procedure eigvals_rdp
 
    module procedure eig_rdp
-      real(dp), allocatable :: Amat(:, :)
-      Amat = dense(A) ; call eig(Amat, lambda, right=right, left=left, overwrite_a=.true.)
+   real(dp), allocatable :: Amat(:, :)
+   Amat = dense(A); call eig(Amat, lambda, right=right, left=left, overwrite_a=.true.)
    end procedure eig_rdp
 end submodule toeplitz_eigendecomposition

--- a/src/Toeplitz/eig.f90
+++ b/src/Toeplitz/eig.f90
@@ -3,10 +3,10 @@ submodule (specialmatrices_toeplitz) toeplitz_eigendecomposition
 contains
    module procedure eigvals_rdp
       lambda = eigvals(dense(A))
-   end procedure
+   end procedure eigvals_rdp
 
    module procedure eig_rdp
       real(dp), allocatable :: Amat(:, :)
       Amat = dense(A) ; call eig(Amat, lambda, right=right, left=left, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure eig_rdp
+end submodule toeplitz_eigendecomposition

--- a/src/Toeplitz/matvecs.f90
+++ b/src/Toeplitz/matvecs.f90
@@ -1,24 +1,25 @@
 submodule(specialmatrices_toeplitz) toeplitz_matvecs
+   implicit none(type, external)
 contains
    module procedure spmv
    integer(ilp) :: m, n
    real(dp), allocatable :: x_circ(:), y_circ(:)
    !> Dimension of the matrix.
-   m = A%m ; n = A%n
+   m = A%m; n = A%n
    !> Allocate variables.
-   allocate(x_circ(m+n)) ; x_circ = 0.0_dp ; x_circ(:n) = x
+   allocate (x_circ(m + n), source=0.0_dp); x_circ(:n) = x
    !> Toeplitz spmv via Circulant embedding.
-   y_circ = matmul(Circulant(A), x_circ) ; y = y_circ(:m)
+   y_circ = matmul(Circulant(A), x_circ); y = y_circ(:m)
    end procedure spmv
 
    module procedure spmvs
    integer(ilp) :: m, n
    real(dp), allocatable :: x_circ(:, :), y_circ(:, :)
    !> Dimension of the matrix.
-   m = A%m ; n = A%n
+   m = A%m; n = A%n
    !> Allocate variables.
-   allocate(x_circ(m+n, size(x, 2))) ; x_circ = 0.0_dp ; x_circ(:n, :) = x
+   allocate (x_circ(m + n, size(x, 2)), source=0.0_dp); x_circ(:n, :) = x
    !> Toeplitz spmv via Circulant embedding.
-   y_circ = matmul(Circulant(A), x_circ) ; y = y_circ(:m, :)
+   y_circ = matmul(Circulant(A), x_circ); y = y_circ(:m, :)
    end procedure spmvs
 end submodule toeplitz_matvecs

--- a/src/Toeplitz/matvecs.f90
+++ b/src/Toeplitz/matvecs.f90
@@ -9,7 +9,7 @@ contains
    allocate(x_circ(m+n)) ; x_circ = 0.0_dp ; x_circ(:n) = x
    !> Toeplitz spmv via Circulant embedding.
    y_circ = matmul(Circulant(A), x_circ) ; y = y_circ(:m)
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    integer(ilp) :: m, n
@@ -20,5 +20,5 @@ contains
    allocate(x_circ(m+n, size(x, 2))) ; x_circ = 0.0_dp ; x_circ(:n, :) = x
    !> Toeplitz spmv via Circulant embedding.
    y_circ = matmul(Circulant(A), x_circ) ; y = y_circ(:m, :)
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule toeplitz_matvecs

--- a/src/Toeplitz/solve.f90
+++ b/src/Toeplitz/solve.f90
@@ -13,7 +13,7 @@ contains
       allocate(x, mold=b)
       !> Solve the linear system with preconditioned GMRES.
       x = gmres(A, b)
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
       integer(ilp) :: i
@@ -22,7 +22,7 @@ contains
       do i = 1, size(b, 2)
          x(:, i) = solve(A, b(:, i))
       enddo
-   end procedure
+   end procedure solve_multi_rhs
 
    !--------------------------------------------
    !-----     CIRCULANT PRECONDITIONER     -----
@@ -33,10 +33,10 @@ contains
       type(Circulant)            :: C
       real(dp), allocatable      :: c_vec(:)
       integer(ilp)               :: i, n, n2
-      
+
       !> Dimension of the matrix.
       n = size(T, 1) ; n2 = n/2
-      
+
       !> Circulant vector.
       allocate(c_vec(n))
       do concurrent(i=1:n2+1)
@@ -48,7 +48,7 @@ contains
 
       !> Circulant matrix.
       C = Circulant(c_vec)
-   end function
+   end function strang_preconditioner
 
    !-------------------------------------------
    !-----     ITERATIVE SOLVER: GMRES     -----
@@ -90,7 +90,7 @@ contains
 
       !> Preconditioner.
       P = strang_preconditioner(A)
-   
+
       !> Set the tolerance.
       tol = atol + norm(b, 2)*rtol
 
@@ -146,7 +146,7 @@ contains
          !> Update the solution.
          x = x + solve(P, matmul(V(:, :k), y))
       enddo
-   end function
+   end function gmres
 
   !------------------------------------
   !-----     GIVENS ROTATIONS     -----
@@ -158,7 +158,7 @@ contains
     real(dp)             :: g(2)
     !! Entries of the Givens rotation matrix.
     g = x / norm(x, 2)
-  end function
+  end function givens_rotation
 
   pure subroutine apply_givens_rotation(h, c, s)
     real(dp), intent(inout) :: h(:)
@@ -187,7 +187,7 @@ contains
 
     !> Eliminate H(k+1, k).
     h(k) = c(k)*h(k) + s(k)*h(k+1) ; h(k+1) = 0.0_dp
-  end subroutine
+  end subroutine apply_givens_rotation
 
   !-------------------------------------------
   !-----     Upper Triangular solver     -----
@@ -213,6 +213,6 @@ contains
       x(i) = b(i) - dot_product(A(i, i+1:), x(i+1:))
       x(i) = x(i) / A(i, i)
     enddo
-  end function
+  end function solve_triangular
 
-end submodule
+end submodule toeplitz_linear_solver

--- a/src/Toeplitz/solve.f90
+++ b/src/Toeplitz/solve.f90
@@ -3,25 +3,25 @@ submodule(specialmatrices_toeplitz) toeplitz_linear_solver
    implicit none(type, external)
 contains
    module procedure solve_single_rhs
-      integer(ilp) :: m, n
+   integer(ilp) :: m, n
 
-      !> Sanity checks.
-      m = size(A, 1) ; n = size(A, 2)
-      if (m /= n) error stop "Matrix is not square."
-      if (size(b) /= n) error stop "Dimension of b is inconsistent with A."
+   !> Sanity checks.
+   m = size(A, 1); n = size(A, 2)
+   if (m /= n) error stop "Matrix is not square."
+   if (size(b) /= n) error stop "Dimension of b is inconsistent with A."
 
-      allocate(x, mold=b)
-      !> Solve the linear system with preconditioned GMRES.
-      x = gmres(A, b)
+   allocate (x, mold=b)
+   !> Solve the linear system with preconditioned GMRES.
+   x = gmres(A, b)
    end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
-      integer(ilp) :: i
-      allocate(x, mold=b)
-      ! do concurrent(i=1:size(b, 2))
-      do i = 1, size(b, 2)
-         x(:, i) = solve(A, b(:, i))
-      enddo
+   integer(ilp) :: i
+   allocate (x, mold=b)
+   ! do concurrent(i=1:size(b, 2))
+   do i = 1, size(b, 2)
+      x(:, i) = solve(A, b(:, i))
+   end do
    end procedure solve_multi_rhs
 
    !--------------------------------------------
@@ -35,16 +35,16 @@ contains
       integer(ilp)               :: i, n, n2
 
       !> Dimension of the matrix.
-      n = size(T, 1) ; n2 = n/2
+      n = size(T, 1); n2 = n/2
 
       !> Circulant vector.
-      allocate(c_vec(n))
-      do concurrent(i=1:n2+1)
+      allocate (c_vec(n))
+      do concurrent(i=1:n2 + 1)
          c_vec(i) = T%vc(i)
-      enddo
-      do concurrent(i=n2+2:n)
-         c_vec(i) = T%vr(n-i+2)
-      enddo
+      end do
+      do concurrent(i=n2 + 2:n)
+         c_vec(i) = T%vr(n - i + 2)
+      end do
 
       !> Circulant matrix.
       C = Circulant(c_vec)
@@ -68,25 +68,25 @@ contains
       real(dp), allocatable :: V(:, :)       !  Krylov basis.
       type(Circulant) :: P                   !  Circulant Preconditioner.
 
-     !> Givens rotations.
+      !> Givens rotations.
       real(dp), allocatable :: c(:), s(:)    !  Cosine and sine components.
 
       !> Miscellaneous.
       real(dp), allocatable :: e(:), y(:)    !  Right-hand side and solution of the lstsq.
-      real(dp), parameter :: atol = 10.0_dp ** (-precision(1.0_dp))  !  Absolute tolerance.
-      real(dp), parameter :: rtol = 10.0_dp ** (-8)                  !  Relative tolerance.
+      real(dp), parameter :: atol = 10.0_dp**(-precision(1.0_dp))  !  Absolute tolerance.
+      real(dp), parameter :: rtol = 10.0_dp**(-8)                  !  Relative tolerance.
       real(dp) :: tol                                                !  Actual tolerance.
       real(dp) :: eps, beta
       logical(lk) :: converged
       integer(ilp) :: i, k
 
       !----- Allocate and initialize working arrays -----
-      allocate(x, mold=b)           ;  x = 0.0_dp  !  Solution vector.
-      allocate(H(kmax+1, kmax))     ;  H = 0.0_dp  !  Upper Hessenberg matrix.
-      allocate(V(size(b), kmax+1))  ;  V = 0.0_dp  !  Krylov basis.
-      allocate(e(kmax+1))           ;  e = 0.0_dp  !  Lstsq right-hand side vector.
-      allocate(c(kmax))             ;  c = 0.0_dp  !  Cosine component of the Givens rotations.
-      allocate(s(kmax))             ;  s = 0.0_dp  !  Sine component of the Givens rotations.
+      allocate (x, mold=b); x = 0.0_dp  !  Solution vector.
+      allocate (H(kmax + 1, kmax)); H = 0.0_dp  !  Upper Hessenberg matrix.
+      allocate (V(size(b), kmax + 1)); V = 0.0_dp  !  Krylov basis.
+      allocate (e(kmax + 1)); e = 0.0_dp  !  Lstsq right-hand side vector.
+      allocate (c(kmax)); c = 0.0_dp  !  Cosine component of the Givens rotations.
+      allocate (s(kmax)); s = 0.0_dp  !  Sine component of the Givens rotations.
 
       !> Preconditioner.
       P = strang_preconditioner(A)
@@ -98,121 +98,121 @@ contains
       converged = .false.
       do while (.not. converged)
          !> Initialize data.
-         H = 0.0_dp ; V = 0.0_dp ; V(:, 1) = b - matmul(A, x)
-         e = 0.0_dp ; e(1) = norm(V(:, 1), 2)
-         c = 0.0_dp ; s = 0.0_dp
+         H = 0.0_dp; V = 0.0_dp; V(:, 1) = b - matmul(A, x)
+         e = 0.0_dp; e(1) = norm(V(:, 1), 2)
+         c = 0.0_dp; s = 0.0_dp
 
          if (e(1) > tol) then
-            V(:, 1) = V(:, 1) / e(1)
+            V(:, 1) = V(:, 1)/e(1)
          else
             converged = .true.
             exit
-         endif
+         end if
 
          !> GMRES iterations.
          gmres_step: do k = 1, kmax
             !> Generate new Krylov vector.
-            V(:, k+1) = matmul(A, solve(P, V(:, k)))
+            V(:, k + 1) = matmul(A, solve(P, V(:, k)))
 
             !> Orthogonalization step.
             gram_schmidt: do i = 1, k
-               H(i, k) = dot_product(V(:, k+1), V(:, i))
-               V(:, k+1) = V(:, k+1) - H(i, k)*V(:, i)
-            enddo gram_schmidt
+               H(i, k) = dot_product(V(:, k + 1), V(:, i))
+               V(:, k + 1) = V(:, k + 1) - H(i, k)*V(:, i)
+            end do gram_schmidt
 
             !> Twice is enough.
             do i = 1, k
-               eps = dot_product(V(:, k+1), V(:, i))
-               V(:, k+1) = V(:, k+1) - eps*V(:, i)
+               eps = dot_product(V(:, k + 1), V(:, i))
+               V(:, k + 1) = V(:, k + 1) - eps*V(:, i)
                H(i, k) = H(i, k) + eps
-            enddo
+            end do
 
             !> Normalize Krylov vector.
-            H(k+1, k) = norm(V(:, k+1), 2)
-            if (H(k+1, k) > atol) V(:, k+1) = V(:, k+1) / H(k+1, k)
+            H(k + 1, k) = norm(V(:, k + 1), 2)
+            if (H(k + 1, k) > atol) V(:, k + 1) = V(:, k + 1)/H(k + 1, k)
 
             !> Apply Givens rotations to the Hessenberg matrix.
-            call apply_givens_rotation(H(:k+1, k), c(:k), s(:k))
+            call apply_givens_rotation(H(:k + 1, k), c(:k), s(:k))
             !> Update the right-hand side vector accordingly.
-            e(k+1) = -s(k)*e(k) ; e(k) = c(k)*e(k)
+            e(k + 1) = -s(k)*e(k); e(k) = c(k)*e(k)
 
             !> Check convergence.
-            if (abs(e(k+1)) < tol) converged = .true.
+            if (abs(e(k + 1)) < tol) converged = .true.
             if (converged) exit gmres_step
-         enddo gmres_step
+         end do gmres_step
 
          !> Solve the least-squares problem.
-         k = min(k, kmax) ; y = solve_triangular(H(:k, :k), e(:k))
+         k = min(k, kmax); y = solve_triangular(H(:k, :k), e(:k))
          !> Update the solution.
          x = x + solve(P, matmul(V(:, :k), y))
-      enddo
+      end do
    end function gmres
 
-  !------------------------------------
-  !-----     GIVENS ROTATIONS     -----
-  !------------------------------------
+   !------------------------------------
+   !-----     GIVENS ROTATIONS     -----
+   !------------------------------------
 
-  pure function givens_rotation(x) result(g)
-    real(dp), intent(in) :: x(2)
+   pure function givens_rotation(x) result(g)
+      real(dp), intent(in) :: x(2)
     !! Vector whose second component needs to be eliminated.
-    real(dp)             :: g(2)
+      real(dp)             :: g(2)
     !! Entries of the Givens rotation matrix.
-    g = x / norm(x, 2)
-  end function givens_rotation
+      g = x/norm(x, 2)
+   end function givens_rotation
 
-  pure subroutine apply_givens_rotation(h, c, s)
-    real(dp), intent(inout) :: h(:)
+   pure subroutine apply_givens_rotation(h, c, s)
+      real(dp), intent(inout) :: h(:)
     !! k-th column of the Hessenberg matrix.
-    real(dp), intent(inout) :: c(:)
+      real(dp), intent(inout) :: c(:)
     !! Cosine components of the Givens rotations.
-    real(dp), intent(inout) :: s(:)
+      real(dp), intent(inout) :: s(:)
     !! Sine components of the Givens rotations.
 
-    !----- Internal variables -----
-    integer(ilp) :: i, k
-    real(dp) :: t, g(2)
+      !----- Internal variables -----
+      integer(ilp) :: i, k
+      real(dp) :: t, g(2)
 
-    !> Size of the column.
-    k = size(h)-1
+      !> Size of the column.
+      k = size(h) - 1
 
-    !> Apply previous Givens rotations to this new column.
-    do i = 1, k-1
-      t = c(i)*h(i) + s(i)*h(i+1)
-      h(i+1) = -s(i)*h(i) + c(i)*h(i+1)
-      h(i) = t
-    enddo
+      !> Apply previous Givens rotations to this new column.
+      do i = 1, k - 1
+         t = c(i)*h(i) + s(i)*h(i + 1)
+         h(i + 1) = -s(i)*h(i) + c(i)*h(i + 1)
+         h(i) = t
+      end do
 
-    !> Compute the sine and cosine components for the next rotation.
-    g = givens_rotation([h(k), h(k+1)]) ; c(k) = g(1) ; s(k) = g(2)
+      !> Compute the sine and cosine components for the next rotation.
+      g = givens_rotation([h(k), h(k + 1)]); c(k) = g(1); s(k) = g(2)
 
-    !> Eliminate H(k+1, k).
-    h(k) = c(k)*h(k) + s(k)*h(k+1) ; h(k+1) = 0.0_dp
-  end subroutine apply_givens_rotation
+      !> Eliminate H(k+1, k).
+      h(k) = c(k)*h(k) + s(k)*h(k + 1); h(k + 1) = 0.0_dp
+   end subroutine apply_givens_rotation
 
-  !-------------------------------------------
-  !-----     Upper Triangular solver     -----
-  !-------------------------------------------
+   !-------------------------------------------
+   !-----     Upper Triangular solver     -----
+   !-------------------------------------------
 
-  pure function solve_triangular(A, b) result(x)
-    real(dp), intent(in) :: A(:, :)
+   pure function solve_triangular(A, b) result(x)
+      real(dp), intent(in) :: A(:, :)
     !! Matrix to invert.
-    real(dp), intent(in) :: b(:)
+      real(dp), intent(in) :: b(:)
     !! Right-hand side vector.
-    real(dp), allocatable :: x(:)
+      real(dp), allocatable :: x(:)
     !! Solution vector.
 
-    !----- Internal variables ------
-    integer(ilp) :: i, j, n
+      !----- Internal variables ------
+      integer(ilp) :: i, j, n
 
-    !> Get problem's dimension.
-    n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_dp
+      !> Get problem's dimension.
+      n = size(A, 1); allocate (x, mold=b); x = 0.0_dp
 
-    !> Back-substitution algorithm.
-    x(n) = b(n) / A(n, n)
-    do i = n-1, 1, -1
-      x(i) = b(i) - dot_product(A(i, i+1:), x(i+1:))
-      x(i) = x(i) / A(i, i)
-    enddo
-  end function solve_triangular
+      !> Back-substitution algorithm.
+      x(n) = b(n)/A(n, n)
+      do i = n - 1, 1, -1
+         x(i) = b(i) - dot_product(A(i, i + 1:), x(i + 1:))
+         x(i) = x(i)/A(i, i)
+      end do
+   end function solve_triangular
 
 end submodule toeplitz_linear_solver

--- a/src/Toeplitz/specialmatrices_toeplitz.f90
+++ b/src/Toeplitz/specialmatrices_toeplitz.f90
@@ -1,7 +1,7 @@
 module specialmatrices_toeplitz
    use stdlib_linalg_constants, only: dp, ilp, lk
    use stdlib_linalg, only: eig, eigvals, svd, svdvals
-   use specialmatrices_circulant
+   use specialmatrices_circulant, only: circulant, matmul, solve
    implicit none(type, external)
    private
 
@@ -78,6 +78,7 @@ module specialmatrices_toeplitz
       !! @endnote
       pure module function construct(vc, vr) result(A)
          !! Construct a `Toeplitz` matrix from the rank-1 arrays `vc` and `vr`.
+         implicit none(type, external)
          real(dp), intent(in) :: vc(:)
          !! First column of the matrix.
          real(dp), intent(in) :: vr(:)
@@ -91,6 +92,7 @@ module specialmatrices_toeplitz
       !! Utility function to embed an m x n `Toeplitz` matrix into an
       !! (m+n) x (m+n) `Circulant` matrix.
       pure module function Toeplitz2Circulant(T) result(C)
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: T
          type(Circulant) :: C
       end function Toeplitz2Circulant
@@ -123,6 +125,7 @@ module specialmatrices_toeplitz
       pure module function spmv(A, x) result(y)
          !! Compute the matrix-vector product for a `Toeplitz` matrix \(A\).
          !! Both `x` and `y` are rank-1 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:)
@@ -134,6 +137,7 @@ module specialmatrices_toeplitz
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Toeplitz` matrix `A`.
          !! Both `X` and `Y` are rank-2 arrays with the same kind as `A`.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: x(:, :)
@@ -181,6 +185,7 @@ module specialmatrices_toeplitz
          !! Solve the linear system \(Ax=b\) where \(A\) is `Toeplitz` and `b`
          !! a standard rank-1 array. The solution vector `x` has the same
          !! dimension and kind as the right-hand side vector `b`.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:)
@@ -193,6 +198,7 @@ module specialmatrices_toeplitz
          !! Solve the linear system \(AX=B\), where `A` is `Toeplitz` and `B`
          !! is a rank-2 array. The solution matrix `X` has the same dimension
          !! and kind as the right-hand side matrix `B`.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: B(:, :)
@@ -231,6 +237,7 @@ module specialmatrices_toeplitz
       !! @endnote
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -275,6 +282,7 @@ module specialmatrices_toeplitz
       !! @endnote
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: s(:)
@@ -317,6 +325,7 @@ module specialmatrices_toeplitz
       module function eigvals_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real `Toeplitz`
          !! matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
@@ -361,6 +370,7 @@ module specialmatrices_toeplitz
       module subroutine eig_rdp(A, lambda, left, right)
          !! Utility function to compute the eigenvalues and eigenvectors of a
          !! `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          complex(dp), intent(out) :: lambda(:)
@@ -391,6 +401,7 @@ module specialmatrices_toeplitz
       !! - `B` :  Rank-2 array representation of the matrix \( A \).
       pure module function dense_rdp(A) result(B)
          !! Utility function to convert a `Toeplitz` matrix to a rank-2 array.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -416,6 +427,7 @@ module specialmatrices_toeplitz
       !! - `B` :  Resulting transposed matrix. It is of the same type as `A`.
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          type(Toeplitz) :: B
@@ -427,6 +439,7 @@ module specialmatrices_toeplitz
       !! Utility function to return the size of `Toeplitz` matrix along a
       !! given dimension.
       pure module function size_rdp(A, dim) result(arr_size)
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -440,6 +453,7 @@ module specialmatrices_toeplitz
       !! Utility function to return the size of a `Toeplitz` matrix.
       pure module function shape_rdp(A) result(arr_shape)
          !! Utility function to get the shape of a `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -450,6 +464,7 @@ module specialmatrices_toeplitz
    interface operator(*)
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Utility function to perform a scalar multiplication with a `Toeplitz` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Toeplitz), intent(in) :: A
          type(Toeplitz) :: B
@@ -457,6 +472,7 @@ module specialmatrices_toeplitz
 
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Utility function to perform a scalar multiplication with a `Toeplitz` matrix.
+         implicit none(type, external)
          type(Toeplitz), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Toeplitz) :: B

--- a/src/Toeplitz/specialmatrices_toeplitz.f90
+++ b/src/Toeplitz/specialmatrices_toeplitz.f90
@@ -34,7 +34,7 @@ module specialmatrices_toeplitz
       !! First column of the matrix.
       real(dp), allocatable :: vr(:)
       !! First row of the matrix.
-   end type
+   end type Toeplitz
 
    !--------------------------------
    !-----     Constructors     -----
@@ -84,7 +84,7 @@ module specialmatrices_toeplitz
          !! First row of the matrix.
          type(Toeplitz) :: A
          !! Corresponding Toeplitz matrix.
-      end function
+      end function construct
    end interface
 
    interface Circulant
@@ -93,7 +93,7 @@ module specialmatrices_toeplitz
       pure module function Toeplitz2Circulant(T) result(C)
          type(Toeplitz), intent(in) :: T
          type(Circulant) :: C
-      end function
+      end function Toeplitz2Circulant
    end interface
 
    !-------------------------------------------------------------------
@@ -129,7 +129,7 @@ module specialmatrices_toeplitz
          !! Input vector.
          real(dp), allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, X) result(Y)
          !! Compute the matrix-matrix product for a `Toeplitz` matrix `A`.
@@ -140,7 +140,7 @@ module specialmatrices_toeplitz
          !! Input matrix.
          real(dp), allocatable :: y(:, :)
          !! Output matrix.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -187,7 +187,7 @@ module specialmatrices_toeplitz
          !! Right-hand side vector.
          real(dp), allocatable :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       pure module function solve_multi_rhs(A, B) result(X)
          !! Solve the linear system \(AX=B\), where `A` is `Toeplitz` and `B`
@@ -199,7 +199,7 @@ module specialmatrices_toeplitz
          !! Right-hand side vectors.
          real(dp), allocatable :: X(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    !------------------------------------------------
@@ -235,7 +235,7 @@ module specialmatrices_toeplitz
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -283,7 +283,7 @@ module specialmatrices_toeplitz
          !! Left singular vectors as columns.
          real(dp), optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -321,7 +321,7 @@ module specialmatrices_toeplitz
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvals_rdp
    end interface
 
    interface eig
@@ -367,7 +367,7 @@ module specialmatrices_toeplitz
          !! Eigenvalues.
          complex(dp), optional, intent(out) :: right(:, :), left(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eig_rdp
    end interface
 
    !-------------------------------------
@@ -395,7 +395,7 @@ module specialmatrices_toeplitz
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -420,7 +420,7 @@ module specialmatrices_toeplitz
          !! Input matrix.
          type(Toeplitz) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -433,7 +433,7 @@ module specialmatrices_toeplitz
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -444,7 +444,7 @@ module specialmatrices_toeplitz
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -462,4 +462,4 @@ module specialmatrices_toeplitz
          type(Toeplitz) :: B
       end function scalar_multiplication_bis_rdp
    end interface
-end module
+end module specialmatrices_toeplitz

--- a/src/Toeplitz/svd.f90
+++ b/src/Toeplitz/svd.f90
@@ -3,10 +3,10 @@ submodule (specialmatrices_toeplitz) toeplitz_svd
 contains
    module procedure svdvals_rdp
       s = svdvals(dense(A))
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
       real(dp), allocatable :: Amat(:, :)
       Amat = dense(A) ; call svd(Amat, s, u, vt, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure svd_rdp
+end submodule toeplitz_svd

--- a/src/Toeplitz/svd.f90
+++ b/src/Toeplitz/svd.f90
@@ -1,12 +1,12 @@
-submodule (specialmatrices_toeplitz) toeplitz_svd
+submodule(specialmatrices_toeplitz) toeplitz_svd
    implicit none(type, external)
 contains
    module procedure svdvals_rdp
-      s = svdvals(dense(A))
+   s = svdvals(dense(A))
    end procedure svdvals_rdp
 
    module procedure svd_rdp
-      real(dp), allocatable :: Amat(:, :)
-      Amat = dense(A) ; call svd(Amat, s, u, vt, overwrite_a=.true.)
+   real(dp), allocatable :: Amat(:, :)
+   Amat = dense(A); call svd(Amat, s, u, vt, overwrite_a=.true.)
    end procedure svd_rdp
 end submodule toeplitz_svd

--- a/src/Toeplitz/utils.f90
+++ b/src/Toeplitz/utils.f90
@@ -2,52 +2,52 @@ submodule(specialmatrices_toeplitz) toeplitz_utilities
    implicit none(type, external)
 contains
    module procedure dense_rdp
-      integer(ilp) :: i, j, m, n
-      real(dp), allocatable :: t(:)
-      m = A%m ; n = A%n ; allocate(t(-(n-1):m-1)) ; allocate(B(m, n))
-      t(:-1) = A%vr(n:2:-1)
-      t(0:) = A%vc
-      do concurrent(i=1:m, j=1:n)
-         B(i, j) = t(i-j)
-      enddo
+   integer(ilp) :: i, j, m, n
+   real(dp), allocatable :: t(:)
+   m = A%m; n = A%n; allocate (t(-(n - 1):m - 1)); allocate (B(m, n))
+   t(:-1) = A%vr(n:2:-1)
+   t(0:) = A%vc
+   do concurrent(i=1:m, j=1:n)
+      B(i, j) = t(i - j)
+   end do
    end procedure dense_rdp
 
    module procedure transpose_rdp
-      B = Toeplitz(A%vr, A%vc)
+   B = Toeplitz(A%vr, A%vc)
    end procedure transpose_rdp
 
    module procedure size_rdp
-      if (present(dim)) then
-         select case(dim)
-            case (1)
-               arr_size = A%m
-            case (2)
-               arr_size = A%n
-            case default
-               error stop "Matrix has only two dimensions."
-         end select
-      else
-         arr_size = A%m * A%n
-      endif
+   if (present(dim)) then
+      select case (dim)
+      case (1)
+         arr_size = A%m
+      case (2)
+         arr_size = A%n
+      case default
+         error stop "Matrix has only two dimensions."
+      end select
+   else
+      arr_size = A%m*A%n
+   end if
    end procedure size_rdp
 
    module procedure shape_rdp
-      arr_shape = [A%m, A%n]
+   arr_shape = [A%m, A%n]
    end procedure shape_rdp
 
    module procedure scalar_multiplication_rdp
-      B = Toeplitz(alpha*A%vc, alpha*A%vr)
+   B = Toeplitz(alpha*A%vc, alpha*A%vr)
    end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
-      B = Toeplitz(alpha*A%vc, alpha*A%vr)
+   B = Toeplitz(alpha*A%vc, alpha*A%vr)
    end procedure scalar_multiplication_bis_rdp
 
    module procedure Toeplitz2Circulant
-      real(dp), allocatable :: c_vec(:)
-      integer(ilp) :: m, n
-      m = T%m ; n = T%n ; allocate(c_vec(m+n))
-      c_vec(:m) = T%vc ; c_vec(m+1:) = cshift(T%vr(n:1:-1), -1)
-      C = Circulant(c_vec)
+   real(dp), allocatable :: c_vec(:)
+   integer(ilp) :: m, n
+   m = T%m; n = T%n; allocate (c_vec(m + n))
+   c_vec(:m) = T%vc; c_vec(m + 1:) = cshift(T%vr(n:1:-1), -1)
+   C = Circulant(c_vec)
    end procedure Toeplitz2Circulant
 end submodule toeplitz_utilities

--- a/src/Tridiagonal/constructors.f90
+++ b/src/Tridiagonal/constructors.f90
@@ -4,17 +4,17 @@ contains
    module procedure initialize
    A%n = n; allocate (A%dl(n - 1)); allocate (A%dv(n)); allocate (A%du(n - 1))
    A%dl = 0.0_dp; A%dv = 0.0_dp; A%du = 0.0_dp
-   end procedure
+   end procedure initialize
 
    module procedure construct
    integer(ilp) :: n
    n = size(dv)
    A%n = n; A%dl = dl; A%dv = dv; A%du = du
-   end procedure
+   end procedure construct
 
    module procedure construct_constant
    integer(ilp) :: i
    A%n = n
    A%dl = [(dl, i=1, n - 1)]; A%dv = [(dv, i=1, n)]; A%du = [(du, i=1, n - 1)]
-   end procedure
-end submodule
+   end procedure construct_constant
+end submodule tridiagonal_constructors

--- a/src/Tridiagonal/det.f90
+++ b/src/Tridiagonal/det.f90
@@ -14,5 +14,5 @@ contains
       ! Store previous values.
       f_1 = f_0; f_0 = d
    end do
-   end procedure
-end submodule
+   end procedure det_rdp
+end submodule tridiagonal_determinant

--- a/src/Tridiagonal/eig.f90
+++ b/src/Tridiagonal/eig.f90
@@ -4,11 +4,11 @@ submodule(specialmatrices_tridiagonal) tridiagonal_eigenvalue_decomposition
 contains
    module procedure eigvals_rdp
    lambda = stdlib_eigvals(dense(A))
-   end procedure
+   end procedure eigvals_rdp
 
    module procedure eig_rdp
    real(dp), allocatable :: Amat(:, :)
    Amat = dense(A)
    call stdlib_eig(Amat, lambda, right=right, left=left, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure eig_rdp
+end submodule tridiagonal_eigenvalue_decomposition

--- a/src/Tridiagonal/matvecs.f90
+++ b/src/Tridiagonal/matvecs.f90
@@ -15,7 +15,7 @@ contains
    ! Matrix-vector product.
    call lagtm(trans, n, nrhs, alpha, A%dl, A%dv, A%du, xmat, ldx, beta, ymat, ldy)
 
-   end procedure
+   end procedure spmv
 
    module procedure spmvs
    ! Local variables.
@@ -28,5 +28,5 @@ contains
    ! Matrix-vector product.
    call lagtm(trans, n, nrhs, alpha, A%dl, A%dv, A%du, x, ldx, beta, y, ldy)
 
-   end procedure
-end submodule
+   end procedure spmvs
+end submodule tridiagonal_matvecs

--- a/src/Tridiagonal/solve.f90
+++ b/src/Tridiagonal/solve.f90
@@ -153,7 +153,7 @@ contains
 
       ! ----- Allocations -----
       allocate (du2(n - 2), ipiv(n))
-      dl = A%dl; d = A%dv; du = A%du; 
+      dl = A%dl; d = A%dv; du = A%du
       ! ----- LU factorization -----
       call gttrf(n, dl, d, du, du2, ipiv, info)
       call handle_gttrf_info(n, info, err)
@@ -187,12 +187,12 @@ contains
    refine_ = optval(refine, .false.)
    x = b; xmat(1:A%n, 1:1) => x; bmat(1:A%n, 1:1) => b
    xmat = tridiagonal_solver(A, bmat, refine_)
-   end procedure
+   end procedure solve_single_rhs
 
    module procedure solve_multi_rhs
    ! Local variables.
    logical(lk) :: refine_
    refine_ = optval(refine, .false.)
    x = tridiagonal_solver(A, b, refine_)
-   end procedure
-end submodule
+   end procedure solve_multi_rhs
+end submodule tridiagonal_linear_solver

--- a/src/Tridiagonal/specialmatrices_tridiagonal.f90
+++ b/src/Tridiagonal/specialmatrices_tridiagonal.f90
@@ -31,7 +31,7 @@ module specialmatrices_tridiagonal
       !! Dimension of the matrix.
       real(dp), allocatable :: dl(:), dv(:), du(:)
       !! Tridiagonal elements of the matrix.
-   end type
+   end type Tridiagonal
 
    !--------------------------------
    !-----     Constructors     -----
@@ -96,7 +96,7 @@ module specialmatrices_tridiagonal
          !! Dimension of the matrix.
          type(Tridiagonal) :: A
          !! Tridiagonal matrix.
-      end function
+      end function initialize
 
       pure module function construct(dl, dv, du) result(A)
          !! Construct a `Tridiagonal` matrix from the rank-1 arrays `dl`,
@@ -105,7 +105,7 @@ module specialmatrices_tridiagonal
          !! Tridiagonal elements of the matrix.
          type(Tridiagonal) :: A
          !! Tridiagonal matrix.
-      end function
+      end function construct
 
       pure module function construct_constant(dl, dv, du, n) result(A)
          !! Construct a `Tridiagonal` matrix with constant diagonal elements.
@@ -115,7 +115,7 @@ module specialmatrices_tridiagonal
          !! Dimension of the matrix.
          type(Tridiagonal) :: A
          !! Tridiagonal matrix.
-      end function
+      end function construct_constant
    end interface
 
    !-------------------------------------------------------------------
@@ -145,7 +145,7 @@ module specialmatrices_tridiagonal
          !! Input vector.
          real(dp), target, allocatable :: y(:)
          !! Output vector.
-      end function
+      end function spmv
 
       pure module function spmvs(A, x) result(y)
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Tridiagonal`
@@ -157,7 +157,7 @@ module specialmatrices_tridiagonal
          !! Input vectors.
          real(dp), allocatable :: Y(:, :)
          !! Output vectors.
-      end function
+      end function spmvs
    end interface
 
    !-----------------------------------------------
@@ -201,7 +201,7 @@ module specialmatrices_tridiagonal
          !! Whether iterative refinement is used or not.
          real(dp), allocatable, target :: x(:)
          !! Solution vector.
-      end function
+      end function solve_single_rhs
 
       module function solve_multi_rhs(A, b, refine) result(x)
          !! Solve the linear system \(AX=B\) where \(A\) is of type
@@ -215,7 +215,7 @@ module specialmatrices_tridiagonal
          !! Whether iterative refined is used or not.
          real(dp), allocatable, target :: x(:, :)
          !! Solution vectors.
-      end function
+      end function solve_multi_rhs
    end interface
 
    interface inv
@@ -225,7 +225,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
          !! Inverse of `A`.
-      end function
+      end function inv_rdp
    end interface
 
    !-----------------------------------------
@@ -255,7 +255,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          real(dp) :: d
          !! Determinant of the matrix.
-      end function
+      end function det_rdp
    end interface
 
    interface trace
@@ -280,7 +280,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          real(dp) :: tr
          !! Trace of the matrix.
-      end function
+      end function trace_rdp
    end interface
 
    !------------------------------------------------
@@ -310,7 +310,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          real(dp), allocatable :: s(:)
          !! Singular values in descending order.
-      end function
+      end function svdvals_rdp
    end interface
 
    interface svd
@@ -352,7 +352,7 @@ module specialmatrices_tridiagonal
          !! Left singular vectors as columns.
          real(dp), optional, intent(out) :: vt(:, :)
          !! Right singular vectors as rows.
-      end subroutine
+      end subroutine svd_rdp
    end interface
 
    !--------------------------------------------
@@ -383,7 +383,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
          !! Eigenvalues.
-      end function
+      end function eigvals_rdp
    end interface
 
    interface eig
@@ -427,7 +427,7 @@ module specialmatrices_tridiagonal
          !! Eigenvalues.
          complex(dp), optional, intent(out) :: right(:, :), left(:, :)
          !! Eigenvectors.
-      end subroutine
+      end subroutine eig_rdp
    end interface
 
    !-------------------------------------
@@ -457,7 +457,7 @@ module specialmatrices_tridiagonal
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
          !! Output dense rank-2 array.
-      end function
+      end function dense_rdp
    end interface
 
    interface transpose
@@ -483,7 +483,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          type(Tridiagonal) :: B
          !! Transpose of the matrix.
-      end function
+      end function transpose_rdp
    end interface
 
    interface size
@@ -495,7 +495,7 @@ module specialmatrices_tridiagonal
          !! Queried dimension.
          integer(ilp) :: arr_size
          !! Size of the matrix along the dimension dim.
-      end function
+      end function size_rdp
    end interface
 
    interface shape
@@ -505,7 +505,7 @@ module specialmatrices_tridiagonal
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
          !! Shape of the matrix.
-      end function
+      end function shape_rdp
    end interface
 
    interface operator(*)
@@ -524,4 +524,4 @@ module specialmatrices_tridiagonal
       end function scalar_multiplication_bis_rdp
    end interface
 
-end module
+end module specialmatrices_tridiagonal

--- a/src/Tridiagonal/specialmatrices_tridiagonal.f90
+++ b/src/Tridiagonal/specialmatrices_tridiagonal.f90
@@ -92,6 +92,7 @@ module specialmatrices_tridiagonal
       !! @endnote
       pure module function initialize(n) result(A)
          !! Construct a `Tridiagonal` matrix filled with zeros.
+         implicit none(type, external)
          integer(ilp), intent(in) :: n
          !! Dimension of the matrix.
          type(Tridiagonal) :: A
@@ -101,6 +102,7 @@ module specialmatrices_tridiagonal
       pure module function construct(dl, dv, du) result(A)
          !! Construct a `Tridiagonal` matrix from the rank-1 arrays `dl`,
          !! `dv` and `du`.
+         implicit none(type, external)
          real(dp), intent(in) :: dl(:), dv(:), du(:)
          !! Tridiagonal elements of the matrix.
          type(Tridiagonal) :: A
@@ -109,6 +111,7 @@ module specialmatrices_tridiagonal
 
       pure module function construct_constant(dl, dv, du, n) result(A)
          !! Construct a `Tridiagonal` matrix with constant diagonal elements.
+         implicit none(type, external)
          real(dp), intent(in) :: dl, dv, du
          !! Tridiagonal elements of the matrix.
          integer(ilp), intent(in) :: n
@@ -139,6 +142,7 @@ module specialmatrices_tridiagonal
          !! Compute the matrix-vector product \(y = Ax\) for a `Tridiagonal`
          !! matrix \(A\). Both `x` and `y` are rank-1 arrays with the same
          !! kind as `A`.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), target, intent(in) :: x(:)
@@ -151,6 +155,7 @@ module specialmatrices_tridiagonal
          !! Compute the matrix-matrix product \(Y = Ax\) for a `Tridiagonal`
          !! matrix \(A\) and a dense matrix \(X\) (rank-2 array). \(Y\) is
          !! also a rank-2 array with the same dimensions as \(X\).
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(in) :: X(:, :)
@@ -193,6 +198,7 @@ module specialmatrices_tridiagonal
          !! Solve the linear system \(Ax=b\) where \(A\) is of type
          !! `Tridiagonal` and `b` a standard rank-1 array. The solution
          !! vector `x` has the same dimension and kind as `b`.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in), target :: b(:)
@@ -207,6 +213,7 @@ module specialmatrices_tridiagonal
          !! Solve the linear system \(AX=B\) where \(A\) is of type
          !! `Tridiagonal` and `B` a standard rank-2 array. The solution
          !! matrix `X` has the same dimensions and kind as `B`.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Coefficient matrix.
          real(dp), intent(in) :: b(:, :)
@@ -221,6 +228,7 @@ module specialmatrices_tridiagonal
    interface inv
       pure module function inv_rdp(A) result(B)
          !! Compute the inverse of a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: B(:, :)
@@ -251,6 +259,7 @@ module specialmatrices_tridiagonal
       !! - `d` :  Determinant of the matrix.
       pure module function det_rdp(A) result(d)
          !! Compute the determinant of a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: d
@@ -276,6 +285,7 @@ module specialmatrices_tridiagonal
       !! - `tr`:  Trace of the matrix.
       pure module function trace_rdp(A) result(tr)
          !! Compute the trace of a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp) :: tr
@@ -306,6 +316,7 @@ module specialmatrices_tridiagonal
       !! - `s` :  Vector of singular values sorted in decreasing order.
       module function svdvals_rdp(A) result(s)
          !! Compute the singular values of a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), allocatable :: s(:)
@@ -344,6 +355,7 @@ module specialmatrices_tridiagonal
       module subroutine svd_rdp(A, s, u, vt)
          !! Compute the singular value decomposition of a `Tridiagonal`
          !! matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          real(dp), intent(out) :: s(:)
@@ -379,6 +391,7 @@ module specialmatrices_tridiagonal
       module function eigvals_rdp(A) result(lambda)
          !! Utility function to compute the eigenvalues of a real
          !! `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          complex(dp), allocatable :: lambda(:)
@@ -421,6 +434,7 @@ module specialmatrices_tridiagonal
       module subroutine eig_rdp(A, lambda, left, right)
          !! Utility function to compute the eigenvalues and eigenvectors of
          !! a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          complex(dp), intent(out) :: lambda(:)
@@ -453,6 +467,7 @@ module specialmatrices_tridiagonal
       module function dense_rdp(A) result(B)
          !! Utility function to convert a `Tridiagonal` matrix to a rank-2
          !! array.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input diagonal matrix.
          real(dp), allocatable :: B(:, :)
@@ -479,6 +494,7 @@ module specialmatrices_tridiagonal
       pure module function transpose_rdp(A) result(B)
          !! Utility function to compute the transpose of a `Tridiagonal`
          !! matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          type(Tridiagonal) :: B
@@ -489,6 +505,7 @@ module specialmatrices_tridiagonal
    interface size
       pure module function size_rdp(A, dim) result(arr_size)
          !! Return the size of `Tridiagonal` matrix along a given dimension.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp), optional, intent(in) :: dim
@@ -501,6 +518,7 @@ module specialmatrices_tridiagonal
    interface shape
       pure module function shape_rdp(A) result(arr_shape)
          !! Return the shape of a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          !! Input matrix.
          integer(ilp) :: arr_shape(2)
@@ -511,6 +529,7 @@ module specialmatrices_tridiagonal
    interface operator(*)
       pure module function scalar_multiplication_rdp(alpha, A) result(B)
          !! Scalar multiplication with a `Tridiagonal` matrix.
+         implicit none(type, external)
          real(dp), intent(in) :: alpha
          type(Tridiagonal), intent(in) :: A
          type(Tridiagonal) :: B
@@ -518,6 +537,7 @@ module specialmatrices_tridiagonal
 
       pure module function scalar_multiplication_bis_rdp(A, alpha) result(B)
          !! Scalar multiplication with a `Tridiagonal` matrix.
+         implicit none(type, external)
          type(Tridiagonal), intent(in) :: A
          real(dp), intent(in) :: alpha
          type(Tridiagonal) :: B

--- a/src/Tridiagonal/svd.f90
+++ b/src/Tridiagonal/svd.f90
@@ -4,11 +4,11 @@ submodule(specialmatrices_tridiagonal) tridiagonal_singular_value_decomposition
 contains
    module procedure svdvals_rdp
    s = stdlib_svdvals(dense(A))
-   end procedure
+   end procedure svdvals_rdp
 
    module procedure svd_rdp
    real(dp), allocatable :: Amat(:, :)
    Amat = dense(A)
    call stdlib_svd(Amat, s, u, vt, overwrite_a=.true.)
-   end procedure
-end submodule
+   end procedure svd_rdp
+end submodule tridiagonal_singular_value_decomposition

--- a/src/Tridiagonal/trace.f90
+++ b/src/Tridiagonal/trace.f90
@@ -3,5 +3,5 @@ submodule(specialmatrices_tridiagonal) tridiagonal_trace
 contains
    module procedure trace_rdp
    tr = sum(A%dv)
-   end procedure
-end submodule
+   end procedure trace_rdp
+end submodule tridiagonal_trace

--- a/src/Tridiagonal/utils.f90
+++ b/src/Tridiagonal/utils.f90
@@ -11,26 +11,26 @@ contains
       B(i, i + 1) = A%du(i)
    end do
    B(n, n - 1) = A%dl(n - 1); B(n, n) = A%dv(n)
-   end procedure
+   end procedure dense_rdp
 
    module procedure transpose_rdp
    B = A
-   end procedure
+   end procedure transpose_rdp
 
    module procedure shape_rdp
    arr_shape = A%n
-   end procedure
+   end procedure shape_rdp
 
    module procedure size_rdp
    arr_size = A%n
-   end procedure
+   end procedure size_rdp
 
    module procedure scalar_multiplication_rdp
    B = Tridiagonal(alpha*A%dl, alpha*A%dv, alpha*A%du)
-   end procedure
+   end procedure scalar_multiplication_rdp
 
    module procedure scalar_multiplication_bis_rdp
    B = Tridiagonal(alpha*A%dl, alpha*A%dv, alpha*A%du)
-   end procedure
+   end procedure scalar_multiplication_bis_rdp
 
-end submodule
+end submodule tridiagonal_utils

--- a/test/Tester.f90
+++ b/test/Tester.f90
@@ -4,17 +4,17 @@ program Tester
    ! Unit-test utility.
    use testdrive, only: run_testsuite, new_testsuite, testsuite_type
    ! List of tests.
-   use test_diagonal
-   use test_bidiagonal
-   use test_tridiagonal
-   use test_symtridiagonal
-   use test_strang
-   use test_poisson2D
-   use test_circulant
-   use test_toeplitz
-   use test_hankel
+   use test_diagonal, only: collect_diagonal_testsuite
+   use test_bidiagonal, only: collect_bidiagonal_testsuite
+   use test_tridiagonal, only: collect_tridiagonal_testsuite
+   use test_symtridiagonal, only: collect_symtridiagonal_testsuite
+   use test_strang, only: collect_strang_testsuite
+   use test_poisson2D, only: collect_poisson2D_testsuite
+   use test_circulant, only: collect_circulant_testsuite
+   use test_toeplitz, only: collect_toeplitz_testsuite
+   use test_hankel, only: collect_hankel_testsuite
 
-   implicit none
+   implicit none(type, external)
 
    ! Unit-test related.
    integer :: status, is
@@ -38,15 +38,15 @@ program Tester
    do is = 1, size(testsuites)
       write (output_unit, *) "-----"
       write (output_unit, fmt) "Testing :", testsuites(is)%name
-      write (output_unit, *) "-----", new_line('a')
+      write (output_unit, *) "-----", new_line("a")
       call run_testsuite(testsuites(is)%collect, error_unit, status)
-      write (output_unit, *) new_line('a')
+      write (output_unit, *) new_line("a")
    end do
 
    if (status > 0) then
-      write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
+      write (error_unit, "(i0, 1x, a)") status, "test(s) failed!"
    else if (status == 0) then
-      write (output_unit, *) "All tests succesfully passed!", new_line('a')
+      write (output_unit, *) "All tests succesfully passed!", new_line("a")
    end if
 
-end program
+end program Tester

--- a/test/Tester.f90
+++ b/test/Tester.f90
@@ -12,6 +12,7 @@ program Tester
    use test_poisson2D
    use test_circulant
    use test_toeplitz
+   use test_hankel
 
    implicit none
 
@@ -30,7 +31,8 @@ program Tester
                 new_testsuite("Strang Matrices", collect_strang_testsuite), &
                 new_testsuite("Poisson2D Matrices", collect_poisson2D_testsuite), &
                 new_testsuite("Circulant Matrices", collect_circulant_testsuite), &
-                new_testsuite("Toeplitz Matrices", collect_toeplitz_testsuite) &
+                new_testsuite("Toeplitz Matrices", collect_toeplitz_testsuite), &
+                new_testsuite("Hankel Matrices", collect_hankel_testsuite) &
                 ]
 
    do is = 1, size(testsuites)

--- a/test/test_bidiagonal_matrices.f90
+++ b/test/test_bidiagonal_matrices.f90
@@ -6,8 +6,9 @@ module test_bidiagonal
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: bidiagonal, operator(*), trace, det, matmul, &
+                              solve, svd, svdvals, dense, eig
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 512
@@ -29,7 +30,7 @@ contains
                   new_unittest("Bidiagonal linear solver", test_solve), &
                   ! new_unittest("Bidiagonal eigenvalue decomposition", test_eig), &
                   new_unittest("Bidiagonal singular value decomposition", test_svd) &
-]
+                  ]
       return
    end subroutine collect_bidiagonal_testsuite
 
@@ -147,13 +148,13 @@ contains
       real(dp), allocatable :: dv(:), ev(:)
 
       ! Initialize matrix.
-      allocate (dv(n), ev(n-1)); call random_number(dv); call random_number(ev)
+      allocate (dv(n), ev(n - 1)); call random_number(dv); call random_number(ev)
       A = Bidiagonal(dv, ev)
 
       ! Compare against stdlib_linalg implementation.
       call check(error, is_close(trace(A), trace(dense(A))), &
-      "Bidiagonal trace failed.")
-      
+                 "Bidiagonal trace failed.")
+
    end subroutine test_trace
 
    subroutine test_det(error)
@@ -162,13 +163,13 @@ contains
       real(dp), allocatable :: dv(:), ev(:)
 
       ! Initialize matrix.
-      allocate (dv(n), ev(n-1)); call random_number(dv); call random_number(ev)
+      allocate (dv(n), ev(n - 1)); call random_number(dv); call random_number(ev)
       A = Bidiagonal(dv, ev)
 
       ! Compare against stdlib_linalg implementation.
       call check(error, is_close(det(A), det(dense(A))), &
-      "Bidiagonal det failed.")
-      
+                 "Bidiagonal det failed.")
+
    end subroutine test_det
 
    subroutine test_scalar_multiplication(error)
@@ -241,11 +242,11 @@ contains
       allocate (s(n), u(n, n), vt(n, n))
       call svd(A, s, u, vt)
 
-     ! Check error.
+      ! Check error.
       Amat = matmul(u, matmul(diag(s), vt))
       call check(error, maxval(abs(dense(A) - Amat)) < 10*n**2*epsilon(1.0_dp), &
                  "Bidiagonal svd failed.")
 
       return
    end subroutine test_svd
-end module
+end module test_bidiagonal

--- a/test/test_circulant.f90
+++ b/test/test_circulant.f90
@@ -7,8 +7,10 @@ module test_circulant
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: circulant, operator(*), inv, matmul, solve, &
+                              svd, svdvals, &
+                              eigvals, eig, dense
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 256
@@ -173,23 +175,23 @@ contains
       allocate (dv(n)); call random_number(dv); A = circulant(dv)
 
       ! Compute singular value decomposition.
-      allocate(s(n), u(n, n), vt(n, n))
+      allocate (s(n), u(n, n), vt(n, n))
       call svd(A, s, u, vt)
 
       ! Check orthogonality of the left singular vectors.
       block
-      real(dp), allocatable :: G(:, :)
-      G = matmul(transpose(u), u)
-      call check(error, norm(G - eye(n, mold=1.0_dp), "inf") < 1e-10_dp, &
-                "Orthogonality of the left singular vectors failed.")
+         real(dp), allocatable :: G(:, :)
+         G = matmul(transpose(u), u)
+         call check(error, norm(G - eye(n, mold=1.0_dp), "inf") < 1e-10_dp, &
+                    "Orthogonality of the left singular vectors failed.")
       end block
 
       ! Check orthogonality of the right singular vectors.
       block
-      real(dp), allocatable :: G(:, :)
-      G = matmul(vt, transpose(vt))
-      call check(error, norm(G - eye(n, mold=1.0_dp), "inf") < 1e-10_dp, &
-                 "Orthogonality of the right singular vectors failed.")
+         real(dp), allocatable :: G(:, :)
+         G = matmul(vt, transpose(vt))
+         call check(error, norm(G - eye(n, mold=1.0_dp), "inf") < 1e-10_dp, &
+                    "Orthogonality of the right singular vectors failed.")
       end block
 
       ! Check error.
@@ -213,15 +215,15 @@ contains
       ! Compute singular values.
       lambda = eigvals(A); lambda_stdlib = eigvals(dense(A))
       ! Re-order eigenvalues for comparison.
-      allocate(lambda_check(n)) ; lambda_check = 0.0_dp
+      allocate (lambda_check(n)); lambda_check = 0.0_dp
       do i = 1, n
          do j = 1, n
             if (is_close(lambda(i), lambda_stdlib(j))) then
                lambda_check(j) = lambda_stdlib(j)
                exit
-            endif
-         enddo
-      enddo
+            end if
+         end do
+      end do
       ! Check error.
       call check(error, all_close(lambda_check, lambda_stdlib), &
                  "circulant eigvals failed.")
@@ -247,4 +249,4 @@ contains
       return
    end subroutine test_eig
 
-end module
+end module test_circulant

--- a/test/test_diagonal_matrices.f90
+++ b/test/test_diagonal_matrices.f90
@@ -6,8 +6,10 @@ module test_diagonal
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: diagonal, operator(*), dense, trace, det, &
+                              matmul, solve, inv, &
+                              svdvals, svd, eigh, eigvalsh
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 512
@@ -244,4 +246,4 @@ contains
       return
    end subroutine test_eigh
 
-end module
+end module test_diagonal

--- a/test/test_hankel.f90
+++ b/test/test_hankel.f90
@@ -7,7 +7,7 @@ module test_hankel
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices, only: Hankel, dense, transpose, matmul, operator(*)
+   use SpecialMatrices, only: hankel, dense, transpose, matmul, operator(*)
    implicit none(type, external)
    private
 
@@ -49,7 +49,7 @@ contains
 
       ! Check error.
       call check(error, all_close(dense(transpose(H)), transpose(A)), &
-                 "transposition failed.")
+                 "Transposition failed.")
    end subroutine test_transpose
 
    subroutine test_scalar_multiplication(error)
@@ -69,14 +69,14 @@ contains
 
       ! Check error.
       call check(error, all_close(alpha*dense(A), dense(B)), &
-                 "alpha*toeplitz failed.")
+                 "alpha*Hankel failed.")
       if (allocated(error)) return
 
       ! Matrix-scalar multipliation.
       B = A*alpha
       ! Check error.
       call check(error, all_close(alpha*dense(A), dense(B)), &
-                 "toeplitz*alpha failed.")
+                 "Hankel*alpha failed.")
 
       return
    end subroutine test_scalar_multiplication
@@ -85,7 +85,7 @@ contains
       implicit none(type, external)
       type(error_type), allocatable, intent(out) :: error
       integer, parameter :: m = 8, n = 6
-      type(Hankel) :: A
+      type(hankel) :: A
       real(dp), allocatable :: v(:)
 
       ! Initialize matrix.

--- a/test/test_hankel.f90
+++ b/test/test_hankel.f90
@@ -1,0 +1,117 @@
+module test_hankel
+   ! Fortran standard library.
+   use stdlib_math, only: is_close, all_close
+   use stdlib_sorting, only: sort_index
+   use stdlib_linalg_constants, only: dp, ilp
+   use stdlib_linalg, only: norm
+   ! Testdrive.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   ! SpecialMatrices
+   use SpecialMatrices, only: Hankel, dense, transpose, matmul, operator(*)
+   implicit none(type, external)
+   private
+
+   public :: collect_hankel_testsuite
+contains
+
+   !-------------------------------------
+   !-----     TOEPLITZ MATRICES     -----
+   !-------------------------------------
+
+   subroutine collect_hankel_testsuite(testsuite)
+      implicit none(type, external)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("Hankel matrix transpose", test_transpose), &
+                  new_unittest("Hankel scalar multiplication", test_scalar_multiplication), &
+                  new_unittest("Hankel matmul", test_matmul) &
+                  ]
+      return
+   end subroutine collect_hankel_testsuite
+
+   subroutine test_transpose(error)
+      implicit none(type, external)
+      type(error_type), allocatable, intent(out) :: error
+      integer, parameter :: m = 2, n = 3
+      type(hankel) :: H
+      real(dp) :: v(m + n - 1), A(m, n)
+
+      ! Initialize matrix.
+      A(1, :) = [1.0_dp, 2.0_dp, 3.0_dp]
+      A(2, :) = [2.0_dp, 3.0_dp, 4.0_dp]
+
+      ! Initialize vector.
+      v = [1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp]
+
+      ! Initialize Hankel matrix.
+      H = Hankel(v, m, n)
+
+      ! Check error.
+      call check(error, all_close(dense(transpose(H)), transpose(A)), &
+                 "transposition failed.")
+   end subroutine test_transpose
+
+   subroutine test_scalar_multiplication(error)
+      implicit none(type, external)
+      type(error_type), allocatable, intent(out) :: error
+      integer, parameter :: m = 128, n = 256
+      type(hankel) :: A, B
+      real(dp), allocatable :: v(:)
+      real(dp) :: alpha
+
+      ! Initialize matrix.
+      allocate (v(m + n - 1)); call random_number(v)
+      A = Hankel(v, m, n); call random_number(alpha)
+
+      ! Scalar-matrix multiplication.
+      B = alpha*A
+
+      ! Check error.
+      call check(error, all_close(alpha*dense(A), dense(B)), &
+                 "alpha*toeplitz failed.")
+      if (allocated(error)) return
+
+      ! Matrix-scalar multipliation.
+      B = A*alpha
+      ! Check error.
+      call check(error, all_close(alpha*dense(A), dense(B)), &
+                 "toeplitz*alpha failed.")
+
+      return
+   end subroutine test_scalar_multiplication
+
+   subroutine test_matmul(error)
+      implicit none(type, external)
+      type(error_type), allocatable, intent(out) :: error
+      integer, parameter :: m = 8, n = 6
+      type(Hankel) :: A
+      real(dp), allocatable :: v(:)
+
+      ! Initialize matrix.
+      allocate (v(m + n - 1)); call random_number(v)
+      A = Hankel(v, m, n)
+
+      ! Matrix-vector product.
+      block
+         real(dp), allocatable :: x(:), y(:), y_dense(:)
+         allocate (x(n)); call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Hankel matrix-vector product failed.")
+         if (allocated(error)) return
+      end block
+
+      ! ! Matrix-matrix product.
+      block
+         real(dp), allocatable :: x(:, :), y(:, :), y_dense(:, :)
+         allocate (x(n, n))
+         call random_number(x)
+         y = matmul(A, x); y_dense = matmul(dense(A), x)
+         call check(error, all_close(y, y_dense), &
+                    "Hankel matrix-matrix product failed.")
+      end block
+      return
+   end subroutine test_matmul
+
+end module test_hankel

--- a/test/test_poisson2D.f90
+++ b/test/test_poisson2D.f90
@@ -6,8 +6,8 @@ module test_poisson2D
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: Poisson2D, dense, matmul, solve, eigh, eigvalsh
+   implicit none(type, external)
    private
 
    integer, parameter :: nx = 16, ny = 8, n = nx*ny
@@ -124,4 +124,4 @@ contains
                  "Poisson2D eigh failed.")
       return
    end subroutine test_eigh
-end module
+end module test_poisson2D

--- a/test/test_strang.f90
+++ b/test/test_strang.f90
@@ -6,8 +6,8 @@ module test_strang
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: strang, dense, matmul, solve, det, eigh, trace, eigvalsh
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 512
@@ -154,4 +154,4 @@ contains
                  "Strang eigh failed.")
       return
    end subroutine test_eigh
-end module
+end module test_strang

--- a/test/test_symtridiagonal_matrices.f90
+++ b/test/test_symtridiagonal_matrices.f90
@@ -6,8 +6,11 @@ module test_symtridiagonal
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: symtridiagonal, operator(*), dense, trace, det, &
+                              matmul, solve, &
+                              eigh, eigvalsh, &
+                              svd, svdvals
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 512
@@ -265,4 +268,4 @@ contains
                  "SymTridiagonal svd failed.")
       return
    end subroutine test_svd
-end module
+end module test_symtridiagonal

--- a/test/test_toeplitz.f90
+++ b/test/test_toeplitz.f90
@@ -7,8 +7,8 @@ module test_toeplitz
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: Toeplitz, dense, matmul, solve, operator(*)
+   implicit none(type, external)
    private
 
    integer, parameter :: m = 128, n = 128
@@ -38,9 +38,9 @@ contains
       real(dp) :: alpha
 
       ! Initialize matrix.
-      allocate(vc(m)) ; call random_number(vc)
-      allocate(vr(n)) ; call random_number(vr)
-      A = Toeplitz(vc, vr) ; call random_number(alpha)
+      allocate (vc(m)); call random_number(vc)
+      allocate (vr(n)); call random_number(vr)
+      A = Toeplitz(vc, vr); call random_number(alpha)
 
       ! Scalar-matrix multiplication.
       B = alpha*A
@@ -63,8 +63,8 @@ contains
       real(dp), allocatable :: vc(:), vr(:)
 
       ! Initialize matrix.
-      allocate(vc(m)) ; call random_number(vc)
-      allocate(vr(n)) ; call random_number(vr)
+      allocate (vc(m)); call random_number(vc)
+      allocate (vr(n)); call random_number(vr)
       A = Toeplitz(vc, vr)
 
       ! Matrix-vector product.
@@ -96,8 +96,8 @@ contains
       integer(ilp) :: i
 
       ! Initialize matrix.
-      vr = [(1.0_dp / (i+1), i=1, n)]
-      vc = [(1.0_dp / (i+1), i=1, n)]
+      vr = [(1.0_dp/(i + 1), i=1, n)]
+      vc = [(1.0_dp/(i + 1), i=1, n)]
       A = Toeplitz(vc, vr)
 
       ! Solve with a single right-hand side vector.
@@ -105,7 +105,7 @@ contains
          real(dp), allocatable :: x(:), b(:)
          allocate (b(n))
          ! Random rhs.
-         call random_number(b) ; b = b / norm(b, 2)
+         call random_number(b); b = b/norm(b, 2)
          ! Solve with SpecialMatrices.
          x = solve(A, b)
          ! Check error.
@@ -122,19 +122,19 @@ contains
          ! Random rhs.
          call random_number(b)
          do i = 1, n
-            b(:, i) = b(:, i) / norm(b, 2)
-         enddo
+            b(:, i) = b(:, i)/norm(b, 2)
+         end do
          ! Solve with SpecialMatrices.
          x = solve(A, b)
          ! Check error.
          do i = 1, n
             call check(error, norm(matmul(A, x(:, i)) - b(:, i), 2) <= 1e-8_dp, &
-                      "toeplitz solve with multiple rhs failed.")
+                       "toeplitz solve with multiple rhs failed.")
             if (allocated(error)) return
-         enddo
+         end do
       end block
 
       return
    end subroutine test_solve
 
-end module
+end module test_toeplitz

--- a/test/test_tridiagonal_matrices.f90
+++ b/test/test_tridiagonal_matrices.f90
@@ -6,8 +6,9 @@ module test_tridiagonal
    ! Testdrive.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    ! SpecialMatrices
-   use SpecialMatrices
-   implicit none
+   use SpecialMatrices, only: tridiagonal, operator(*), dense, trace, det, &
+                              matmul, solve, eig, eigvals, svd, svdvals
+   implicit none(type, external)
    private
 
    integer, parameter :: n = 512
@@ -216,11 +217,11 @@ contains
       allocate (s(n), u(n, n), vt(n, n))
       call svd(A, s, u, vt)
 
-     ! Check error.
+      ! Check error.
       Amat = matmul(u, matmul(diag(s), vt))
       call check(error, mnorm(dense(A) - Amat, 2) < 10*n**2*epsilon(1.0_dp), &
                  "Tridiagonal svd failed.")
 
       return
    end subroutine test_svd
-end module
+end module test_tridiagonal


### PR DESCRIPTION
This PR provides the following utilities for Hankel matrices:

- Derived type.
- Dense
- operator(*)
- Fast matrix-vector and matrix-matrix products.